### PR TITLE
Add support for distributed tracing

### DIFF
--- a/helpers/docker-compose.yaml
+++ b/helpers/docker-compose.yaml
@@ -33,3 +33,15 @@ services:
     image: postgres
     ports:
       - "5432:5432"
+
+  jaeger:
+    image: jaegertracing/all-in-one:1.17
+    ports:
+      - 5775:5775/udp
+      - 6831:6831/udp
+      - 6832:6832/udp
+      - 5778:5778
+      - 16686:16686
+      - 14268:14268
+    environment:
+      COLLECTOR_ZIPKIN_HTTP_PORT: 9411

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,14 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
+      <artifactId>quarkus-smallrye-opentracing</artifactId>
+    </dependency>
+    <dependency>
+       <groupId>io.opentracing.contrib</groupId>
+       <artifactId>opentracing-jdbc</artifactId>
+   </dependency>
+    <dependency>
+      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
@@ -39,13 +39,8 @@ import javax.ws.rs.ext.Provider;
  * principal will also be made available for Injection, so that you can write in
  * your code.
  *
-<<<<<<< HEAD
- * We don't yet query for RBAC here, but in its own filter after the
- * JAX-RS engine has selected the endpoint to call.
-=======
  * We don't yet query for RBAC here, as this filter is not part of the tracing
  * span, so we would not be able to trace the rbac calls.
->>>>>>> Add support for distributed tracing
  * See {@link RbacFilter} for this purpose.
  *
  * Usage in code:

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/IncomingRequestFilter.java
@@ -39,8 +39,13 @@ import javax.ws.rs.ext.Provider;
  * principal will also be made available for Injection, so that you can write in
  * your code.
  *
+<<<<<<< HEAD
  * We don't yet query for RBAC here, but in its own filter after the
  * JAX-RS engine has selected the endpoint to call.
+=======
+ * We don't yet query for RBAC here, as this filter is not part of the tracing
+ * span, so we would not be able to trace the rbac calls.
+>>>>>>> Add support for distributed tracing
  * See {@link RbacFilter} for this purpose.
  *
  * Usage in code:

--- a/src/main/java/com/redhat/cloud/custompolicies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/custompolicies/app/auth/RbacFilter.java
@@ -17,6 +17,7 @@
 package com.redhat.cloud.custompolicies.app.auth;
 
 import com.redhat.cloud.custompolicies.app.RbacServer;
+import io.opentracing.Tracer;
 import io.quarkus.cache.CacheResult;
 import java.io.IOException;
 import javax.annotation.Priority;
@@ -35,6 +36,8 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 @Priority(Priorities.HEADER_DECORATOR +1)
 public class RbacFilter implements ContainerRequestFilter {
 
+  @Inject
+  Tracer tracer;
 
   @Inject
   @RestClient

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,9 @@
-quarkus.datasource.url = jdbc:postgresql://localhost:5432/postgres
-quarkus.datasource.driver = org.postgresql.Driver
+quarkus.datasource.url=jdbc:tracing:postgresql://localhost:5432/postgres
+# use the 'TracingDriver' instead of the one for your database
+quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver
+# configure Hibernate dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
+%test.quarkus.datasource.driver = org.postgresql.Driver
 quarkus.datasource.username = postgres
 quarkus.datasource.password = postgres
 
@@ -35,6 +39,10 @@ mp.openapi.filter=com.redhat.cloud.custompolicies.app.openapi.OASModifier
 
 # Filter health calls (hc, metrics) from access log that were successful
 accesslog.filter.health=true
+
+quarkus.jaeger.service-name=custom-policies-api 
+quarkus.jaeger.sampler-type=const
+quarkus.jaeger.sampler-param=1
 
 # Duration rbac entries are kept in cache
 quarkus.cache.caffeine.rbac-cache.expire-after-write=PT120s

--- a/src/test/java/com/redhat/cloud/custompolicies/app/SettingsServiceTest.java
+++ b/src/test/java/com/redhat/cloud/custompolicies/app/SettingsServiceTest.java
@@ -29,7 +29,6 @@ import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.mockserver.client.MockServerClient;
-import org.mockserver.model.HttpRequest;
 
 /**
  * @author hrupp

--- a/src/test/java/com/redhat/cloud/custompolicies/app/TestLifecycleManager.java
+++ b/src/test/java/com/redhat/cloud/custompolicies/app/TestLifecycleManager.java
@@ -73,9 +73,11 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     // quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver
     // Driver needs a 'tracing' in the middle like jdbc:tracing:postgresql://localhost:5432/postgres
     String jdbcUrl = postgreSQLContainer.getJdbcUrl();
+    jdbcUrl = "jdbc:tracing:" + jdbcUrl.substring(jdbcUrl.indexOf(':')+1);
     props.put("quarkus.datasource.url", jdbcUrl);
     props.put("quarkus.datasource.username","test");
     props.put("quarkus.datasource.password","test");
+    props.put("quarkus.datasource.driver","io.opentracing.contrib.jdbc.TracingDriver");
 
   }
 


### PR DESCRIPTION
This is a larger change. I tried this with Quarkus 1.2 but failed (most likely pilot error), so I pulled in 1.3 where I got it to work.

![Bildschirmfoto 2020-03-13 um 11 26 38](https://user-images.githubusercontent.com/208246/76618056-e9de2080-6527-11ea-8b13-f26720786f63.png)


- bump Quarkus to 1.3.0.Final
  +- Change test setup to use QuarkusTestResource
- Pull in MP-OpenTracing and set it up in application.properties.
- Separate out Rbac retrieval from IncomingRequestFilter, as otherwise it would not be part of the outer span (that only starts when the endpoint is hit, but the IRF is a @PreMatch filter, which runs before
- Implement a Rbac cache: This is a simple annotation that creates the cache. Entries expire after 2mins (see application.properties) 

With engine also instrumented :

![Bildschirmfoto 2020-03-13 um 12 42 21](https://user-images.githubusercontent.com/208246/76618172-31fd4300-6528-11ea-92bd-71ed7385adfa.png)

See also https://github.com/RedHatInsights/custom-policies-engine/pull/42

Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>