### PR TITLE
Add default password to helper's postgres container

### DIFF
--- a/helpers/docker-compose.yaml
+++ b/helpers/docker-compose.yaml
@@ -33,6 +33,8 @@ services:
     image: postgres
     ports:
       - "5432:5432"
+    environment:
+        POSTGRES_PASSWORD: postgres
 
   jaeger:
     image: jaegertracing/all-in-one:1.17


### PR DESCRIPTION
Looks like the POSTGRES_PASSWORD is now mandatory:

```
Attaching to helpers_zookeeper_1, helpers_postgres_1, helpers_kafka_1, helpers_jaeger_1
postgres_1   | Error: Database is uninitialized and superuser password is not specified.
postgres_1   |        You must specify POSTGRES_PASSWORD to a non-empty value for the
postgres_1   |        superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
postgres_1   | 
postgres_1   |        You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
postgres_1   |        connections without a password. This is *not* recommended.
postgres_1   | 
postgres_1   |        See PostgreSQL documentation about "trust":
postgres_1   |        https://www.postgresql.org/docs/current/auth-trust.html
helpers_postgres_1 exited with code 1
```

https://hub.docker.com/_/postgres