### PR TITLE
POL-97 Sets lastEvaluation to empty when 0

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/model/Policy.java
+++ b/src/main/java/com/redhat/cloud/policies/app/model/Policy.java
@@ -90,7 +90,7 @@ public class Policy extends PanacheEntityBase {
   private Timestamp mtime=new Timestamp(System.currentTimeMillis());
 
   @Schema(type = SchemaType.STRING,
-          description = "Last evaluation time in a form like '2020-01-24 12:19:56.718', output only",
+          description = "Last evaluation time in a form like '2020-01-24 12:19:56.718', output only, empty if not set",
           readOnly = true,
           format = "yyyy-MM-dd hh:mm:ss.ddd",
           implementation = String.class)
@@ -120,7 +120,11 @@ public class Policy extends PanacheEntityBase {
 
   @JsonbTransient
   public void setLastEvaluation(long lastEvaluation) {
-    this.lastEvaluation = new Timestamp(lastEvaluation);
+    if (lastEvaluation == 0) {
+      this.lastEvaluation = null;
+    } else {
+      this.lastEvaluation = new Timestamp(lastEvaluation);
+    }
   }
 
   public String getLastEvaluation() {

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -521,7 +521,7 @@ public class PolicyCrudService {
             policy.setLastEvaluation(ft.conditions.get(0).lastEvaluation);
           }
         } catch (Exception e) {
-          policy.setLastEvaluation(0); // TODO does this make sense?
+          policy.setLastEvaluation(0);
         }
       }
       builder = Response.ok(policy);


### PR DESCRIPTION
Prevents having to parse stuff like "1969-12-31 18:00:00.0" as "not set"