### PR TITLE
Bump Quarkus to 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <java.release>11</java.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>1.3.0.Final</quarkus.version>
+    <quarkus.version>1.3.1.Final</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
 
     <version.testcontainers>1.12.3</version.testcontainers>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,6 @@ quarkus.datasource.url=jdbc:tracing:postgresql://localhost:5432/postgres
 quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver
 # configure Hibernate dialect
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
-%test.quarkus.datasource.driver = org.postgresql.Driver
 quarkus.datasource.username = postgres
 quarkus.datasource.password = postgres
 


### PR DESCRIPTION
Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

I have no idea if there is a need for a jdbc driver change in the DC when this is installed or not.
There is certainly a change in application.properties respective to 1.3.0 for the case of tests.