### PR TITLE
Introduce explicit timeouts for calls to other services.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -34,16 +34,7 @@ import javax.persistence.EntityManager;
 import javax.persistence.PersistenceException;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.GET;
-import javax.ws.rs.NotFoundException;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
+import javax.ws.rs.*;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.EntityTag;
 import javax.ws.rs.core.Response;
@@ -427,7 +418,8 @@ public class PolicyCrudService {
 
   private Msg getEngineExceptionMsg(Exception e) {
     Msg msg;
-    if (e instanceof RuntimeException && e.getCause() instanceof ConnectException) {
+    if (e instanceof RuntimeException && e.getCause() instanceof ConnectException
+        || e instanceof ProcessingException) {
       msg = new Msg("Connection to backend-engine failed. Please retry later");
     } else {
       msg = new Msg(e.getMessage());

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,13 +22,19 @@ quarkus.flyway.sql-migration-prefix=V
 
 # our engine backend for verification of policies
 engine/mp-rest/url=http://localhost:8084
+engine/mp-rest/connectTimeout=2000
+engine/mp-rest/readTimeout=2000
 
 # RBAC server
 #rbac/mp-rest/url=http://ci.foo.redhat.com:1337
 rbac/mp-rest/url=https://ci.cloud.redhat.com
+rbac/mp-rest/connectTimeout=2000
+rbac/mp-rest/readTimeout=2000
 
 # Notifications server
 notifications/mp-rest/url=http://policies-notifications:8080
+notifications/mp-rest/connectTimeout=2000
+notifications/mp-rest/readTimeout=2000
 
 # OpenAPI path
 quarkus.smallrye-openapi.path=/api/policies/v1.0/openapi.json


### PR DESCRIPTION
 This way the user on the UI does not need to wait for too long if they are in a odd state.

Before this change if you Ctrl-Z the engine, and then refresh the list or click on store in the create-wizard, it would hang "forever". With this change, the rest-request to engine, rbac and notifications is aborted after ~2s and the user either gets a nice error message or in case of list view, the list is shown, but data like lastEvaluated (lastTriggered in the future) will be omitted.


Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

cc @hsagman -- this is something we talked about yesterday