### PR TITLE
PoC: Sync down policies into the engine.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/JaxRsApplication.java
+++ b/src/main/java/com/redhat/cloud/policies/app/JaxRsApplication.java
@@ -47,6 +47,8 @@ public class JaxRsApplication extends Application {
     router.route().order(-1000).handler(handler);
     showVersionInfo();
 
+    // Generate a token
+    TokenHolder.getInstance();
   }
 
   private void showVersionInfo() {

--- a/src/main/java/com/redhat/cloud/policies/app/TokenHolder.java
+++ b/src/main/java/com/redhat/cloud/policies/app/TokenHolder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app;
+
+import java.util.UUID;
+
+/**
+ * @author hrupp
+ */
+public class TokenHolder {
+
+  private static TokenHolder tokenHolder;
+
+  private String token;
+
+  private TokenHolder() {
+    token = UUID.randomUUID().toString();
+    System.out.println("Token: " + token);
+  }
+
+  public boolean compareToken(String input) {
+    return token.equals(input);
+  }
+
+  public static TokenHolder getInstance() {
+    if (tokenHolder==null) {
+      tokenHolder = new TokenHolder();
+    }
+    return tokenHolder;
+  }
+}


### PR DESCRIPTION
PoC of a service, that gets all Policies from the DB, checks if they exist in the engine and if not,
stores them in the engine.

When the app starts, a token is emitted in the logs. This token needs to be given on the URL for the mechanism to work. Also it currently requires a valid rh-identity.
Currently it does not try to sync entries that are different in postgres and engine.

Ideally we would be able to block the endpoint in 3scale.