### PR TITLE
POL-207 Limit Policy.name to 150 characters

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/model/Policy.java
+++ b/src/main/java/com/redhat/cloud/policies/app/model/Policy.java
@@ -38,6 +38,8 @@ import javax.persistence.Query;
 import javax.persistence.Transient;
 import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
@@ -58,6 +60,7 @@ public class Policy extends PanacheEntityBase {
   @NotNull
   @NotEmpty
   @Schema(description = "Name of the rule. Must be unique per customer account.")
+  @Size(max = 150)
   public String name;
 
   @Schema(description = "A short description of the policy.")

--- a/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
@@ -444,6 +444,37 @@ class RestApiTest extends AbstractITest {
   }
 
   @Test
+  void storeNewPolicyWithLongName() {
+    TestPolicy tp = new TestPolicy();
+    tp.conditions = "cores = 2";
+    tp.name = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis pa";
+    given()
+            .header(authHeader)
+            .contentType(ContentType.JSON)
+            .body(tp)
+            .queryParam("alsoStore","false")
+            .when().post(API_BASE_V1_0 + "/policies")
+            .then()
+            .statusCode(400);
+  }
+
+  @Test
+  void editPolicyWithLongName() {
+    TestPolicy tp = new TestPolicy();
+    tp.id = UUID.fromString("bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c");
+    tp.conditions = "cores = 2";
+    tp.name = "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis pa";
+    given()
+            .header(authHeader)
+            .contentType(ContentType.JSON)
+            .body(tp)
+            .queryParam("dry","true")
+            .when().put(API_BASE_V1_0 + "/policies/bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c")
+            .then()
+            .statusCode(400);
+  }
+
+  @Test
   void storeNewPolicyEngineProblem() {
     TestPolicy tp = new TestPolicy();
     tp.actions = "EMAIL";

--- a/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
@@ -456,6 +456,7 @@ class RestApiTest extends AbstractITest {
             .when().post(API_BASE_V1_0 + "/policies")
             .then()
             .statusCode(400);
+    Assert.assertTrue(tp.name.length() > 150);
   }
 
   @Test
@@ -472,6 +473,7 @@ class RestApiTest extends AbstractITest {
             .when().put(API_BASE_V1_0 + "/policies/bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c")
             .then()
             .statusCode(400);
+    Assert.assertTrue(tp.name.length() > 150);
   }
 
   @Test


### PR DESCRIPTION
Also guards the API calls for adding or editing policies with long names.