### PR TITLE
POL-241 Ensure validate-name decodes string from json

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -68,6 +68,7 @@ import org.eclipse.microprofile.openapi.annotations.media.Content;
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameter;
 import org.eclipse.microprofile.openapi.annotations.parameters.Parameters;
+import org.eclipse.microprofile.openapi.annotations.parameters.RequestBody;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
@@ -685,6 +686,7 @@ public class PolicyCrudService {
   @Operation(summary = "Validates the Policy.name and verifies if it is unique.")
   @POST
   @Path("/validate-name")
+  @RequestBody(content = { @Content( schema = @Schema( type = SchemaType.STRING )) })
   @APIResponses({
           @APIResponse(responseCode = "200", description = "Name validated"),
           @APIResponse(responseCode = "400", description = "Policy validation failed"),

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -34,6 +34,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
+import javax.json.JsonString;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceException;
 import javax.transaction.Transactional;
@@ -691,14 +692,14 @@ public class PolicyCrudService {
           @APIResponse(responseCode = "409", description = "Name not unique"),
           @APIResponse(responseCode = "500", description = "Internal error")
   })
-  public Response validateName(@NotNull String policyName, @QueryParam("id") UUID id) {
+  public Response validateName(@NotNull JsonString policyName, @QueryParam("id") UUID id) {
     if (!user.canReadAll()) {
       return Response.status(Response.Status.FORBIDDEN).entity(new Msg("Missing permissions to verify policy")).build();
     }
 
     Policy policy = new Policy();
     policy.id = id;
-    policy.name = policyName;
+    policy.name = policyName.getString();
 
     Set<ConstraintViolation<Policy>> result = validator.validateProperty(policy, "name");
 

--- a/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.inject.Inject;
+import javax.json.Json;
 import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
@@ -1069,7 +1070,7 @@ class RestApiTest extends AbstractITest {
     given()
             .header(authHeader)
             .contentType(ContentType.JSON)
-            .body(name)
+            .body(Json.createValue(name).toString())
             .when().post(API_BASE_V1_0 + "/policies/validate-name")
             .then()
             .statusCode(200);
@@ -1081,7 +1082,7 @@ class RestApiTest extends AbstractITest {
     given()
             .header(authHeader)
             .contentType(ContentType.JSON)
-            .body(name)
+            .body(Json.createValue(name).toString())
             .when().post(API_BASE_V1_0 + "/policies/validate-name")
             .then()
             .statusCode(409);
@@ -1093,7 +1094,7 @@ class RestApiTest extends AbstractITest {
     given()
             .header(authHeader)
             .contentType(ContentType.JSON)
-            .body(name)
+            .body(Json.createValue(name).toString())
             .when().post(API_BASE_V1_0 + "/policies/validate-name")
             .then()
             .statusCode(400);
@@ -1106,7 +1107,7 @@ class RestApiTest extends AbstractITest {
     given()
             .header(authHeader)
             .contentType(ContentType.JSON)
-            .body(name)
+            .body(Json.createValue(name).toString())
             .when().post(API_BASE_V1_0 + "/policies/validate-name?id=bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c")
             .then()
             .statusCode(200);
@@ -1118,7 +1119,7 @@ class RestApiTest extends AbstractITest {
     given()
             .header(authHeader)
             .contentType(ContentType.JSON)
-            .body(name)
+            .body(Json.createValue(name).toString())
             .when().post(API_BASE_V1_0 + "/policies/validate-name?id=bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c")
             .then()
             .statusCode(409);
@@ -1130,7 +1131,7 @@ class RestApiTest extends AbstractITest {
     given()
             .header(authHeader)
             .contentType(ContentType.JSON)
-            .body(name)
+            .body(Json.createValue(name).toString())
             .when().post(API_BASE_V1_0 + "/policies/validate-name?id=bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c")
             .then()
             .statusCode(200);


### PR DESCRIPTION
The frontend is encoding the content as a json, so `ABC` becomes `"ABC"`, but the backend is not honoring the `Content-Type` and taking the plain json string.

This fixes that call and makes the method to specifically expect a `JsonString`.