### PR TITLE
[POL-282] Provide history items for one policy

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,11 @@
       <artifactId>quarkus-cache</artifactId>
     </dependency>
     <dependency>
+        <groupId>com.jayway.jsonpath</groupId>
+        <artifactId>json-path</artifactId>
+        <version>2.4.0</version>
+    </dependency>
+    <dependency>
       <groupId>io.quarkus</groupId>
       <artifactId>quarkus-logging-sentry</artifactId>
     </dependency>
@@ -113,19 +118,19 @@
       <groupId>com.google.code.gson</groupId>
       <artifactId>gson</artifactId>
       <version>2.8.5</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
+    <dependency> <!-- version pulled in from Quarkus bom -->
       <groupId>org.testcontainers</groupId>
       <artifactId>postgresql</artifactId>
-      <version>${version.testcontainers}</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
+    <dependency>  <!-- version pulled in from Quarkus bom -->
       <groupId>org.testcontainers</groupId>
       <artifactId>junit-jupiter</artifactId>
       <scope>test</scope>

--- a/src/main/java/com/redhat/cloud/policies/app/PolicyEngine.java
+++ b/src/main/java/com/redhat/cloud/policies/app/PolicyEngine.java
@@ -121,7 +121,7 @@ public interface PolicyEngine {
 
   @GET
   @Consumes("application/json")
-  List<Alert> findLastTriggered(@QueryParam("triggerIds") String triggerIds,
+  String findLastTriggered(@QueryParam("triggerIds") String triggerIds,
                                 @QueryParam("thin") boolean thin,
                                 @HeaderParam("Hawkular-Tenant") String customerId);
 }

--- a/src/main/java/com/redhat/cloud/policies/app/model/engine/HistoryItem.java
+++ b/src/main/java/com/redhat/cloud/policies/app/model/engine/HistoryItem.java
@@ -16,15 +16,23 @@
  */
 package com.redhat.cloud.policies.app.model.engine;
 
+
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+
 /**
  * A single trigger history item
  * @author hrupp
  */
 
+@Schema(description = "A single history item for a fired trigger on a host")
 public class HistoryItem {
 
+
+  @Schema(description = "Fire time (since the epoch)")
   public long ctime;
+  @Schema(description = "Host id")
   public String id;
+  @Schema(description = "Host name")
   public String hostName;
 
   public HistoryItem(long ctime, String id, String hostName) {

--- a/src/main/java/com/redhat/cloud/policies/app/model/engine/HistoryItem.java
+++ b/src/main/java/com/redhat/cloud/policies/app/model/engine/HistoryItem.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app.model.engine;
+
+/**
+ * A single trigger history item
+ * @author hrupp
+ */
+
+public class HistoryItem {
+
+  public long ctime;
+  public String id;
+  public String hostName;
+
+  public HistoryItem(long ctime, String id, String hostName) {
+    this.ctime = ctime;
+    this.id = id;
+    this.hostName = hostName;
+  }
+}

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -16,6 +16,8 @@
  */
 package com.redhat.cloud.policies.app.rest;
 
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import com.redhat.cloud.policies.app.PolicyEngine;
 import com.redhat.cloud.policies.app.TokenHolder;
 import com.redhat.cloud.policies.app.auth.RhIdPrincipal;
@@ -57,9 +59,11 @@ import javax.ws.rs.PathParam;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.*;
 import javax.ws.rs.core.Response.ResponseBuilder;
 
+import com.redhat.cloud.policies.app.model.engine.HistoryItem;
 import com.redhat.cloud.policies.app.model.engine.Trigger;
 import com.redhat.cloud.policies.app.model.pager.Page;
 import com.redhat.cloud.policies.app.model.pager.Pager;
@@ -239,7 +243,7 @@ public class PolicyCrudService {
             p.setLastTriggered(lastTriggerTime);
           }
         });
-      } catch (ProcessingException|NotFoundException pe ) {
+      } catch (ProcessingException| WebApplicationException pe ) {
         log.warning("Getting lastTrigger time failed: " + pe.getMessage());
       }
     } catch (IllegalArgumentException iae) {
@@ -387,7 +391,7 @@ public class PolicyCrudService {
         id = policy.store(user.getAccount(), policy);
       } catch (Exception e) {
         Msg engineExceptionMsg = getEngineExceptionMsg(e);
-        log.info("Storing policy in engine failed: " + engineExceptionMsg.msg);
+        log.warning("Storing policy in engine failed: " + engineExceptionMsg.msg);
         return Response.status(400,e.getMessage()).entity(engineExceptionMsg).build();
       }
     } catch (Throwable t) {
@@ -428,6 +432,7 @@ public class PolicyCrudService {
   @APIResponse(responseCode = "200", description = "Policy deleted")
   @APIResponse(responseCode = "404", description = "Policy not found")
   @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
+  @Parameter(name = "id", description = "UUID of the policy", schema = @Schema(type = SchemaType.STRING))
   @Transactional
   public Response deletePolicy(@PathParam("id") UUID policyId) {
 
@@ -709,6 +714,7 @@ public class PolicyCrudService {
           @APIResponse(responseCode = "409", description = "Name not unique"),
           @APIResponse(responseCode = "500", description = "Internal error")
   })
+  @Parameter(name = "id", description = "UUID of the policy", schema = @Schema(type = SchemaType.STRING))
   public Response validateName(@NotNull JsonString policyName, @QueryParam("id") UUID id) {
     if (!user.canReadAll()) {
       return Response.status(Response.Status.FORBIDDEN).entity(new Msg("Missing permissions to verify policy")).build();
@@ -744,6 +750,7 @@ public class PolicyCrudService {
                  @Content(schema = @Schema(implementation = Policy.class)))
   @APIResponse(responseCode = "404", description = "Policy not found")
   @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
+  @Parameter(name = "id", description = "UUID of the policy", schema = @Schema(type = SchemaType.STRING))
   public Response getPolicy(@PathParam("id") UUID policyId) {
 
     if (!user.canReadAll()) {
@@ -771,6 +778,53 @@ public class PolicyCrudService {
     }
 
     return builder.build();
+  }
+
+  @Operation(summary = "Retrieve the trigger history of a single policy")
+  @APIResponse(responseCode = "200", description = "History could be retrieved",
+      content = @Content (schema = @Schema(type = SchemaType.ARRAY, implementation = HistoryItem.class)))
+  @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
+  @APIResponse(responseCode = "404", description = "Policy not found")
+  @APIResponse(responseCode = "500", description = "Retrieval of History failed")
+  @Parameter(name = "id", description = "UUID of the policy", schema = @Schema(type = SchemaType.STRING))
+  @GET
+  @Path("/{id}/history/trigger")
+  public Response getTriggerHistoryForPolicy(@PathParam("id") UUID policyId) {
+    if (!user.canReadAll()) {
+       return Response.status(Response.Status.FORBIDDEN).entity(new Msg("Missing permissions to retrieve policies")).build();
+     }
+
+     Policy policy = Policy.findById(user.getAccount(), policyId);
+
+     ResponseBuilder builder ;
+     if (policy==null) {
+       builder = Response.status(Response.Status.NOT_FOUND);
+     } else {
+       try {
+         String alerts = engine.findLastTriggered(policyId.toString(), false, user.getAccount());
+
+         List<HistoryItem> items = new ArrayList<>();
+          DocumentContext jp = JsonPath.parse(alerts);
+          List<Map<String,Object>> list = jp.read("$.[*].evalSets..value");
+//         jp.read("$.[*].evalSets..display_name");
+//         jp.read("$.[*].evalSets..value.ctime");
+//         jp.read("$.[*].evalSets[0][0].value.context.insights_id");
+         for (Map<String,Object> value : list) {
+           long ctime = (long) value.get("ctime");
+           Map<String,Object> tmp = (Map<String, Object>) value.get("context");
+           String insights_id = (String) tmp.get("insights_id");
+           tmp = (Map<String, Object>) value.get("tags");
+           String name = (String) tmp.get("display_name");
+           HistoryItem hi = new HistoryItem(ctime,insights_id,name);
+           items.add(hi);
+         }
+         builder = Response.ok(items);
+       } catch (Exception e) {
+         log.warning("Retrieval of history failed: " + e.getMessage());
+         builder = Response.serverError();
+       }
+     }
+     return builder.build();
   }
 
   /*

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -714,7 +714,7 @@ public class PolicyCrudService {
           @APIResponse(responseCode = "409", description = "Name not unique"),
           @APIResponse(responseCode = "500", description = "Internal error")
   })
-  @Parameter(name = "id", description = "UUID of the policy", schema = @Schema(type = SchemaType.STRING))
+  @Parameter(name = "id", description = "UUID of the policy")
   public Response validateName(@NotNull JsonString policyName, @QueryParam("id") UUID id) {
     if (!user.canReadAll()) {
       return Response.status(Response.Status.FORBIDDEN).entity(new Msg("Missing permissions to verify policy")).build();
@@ -750,7 +750,7 @@ public class PolicyCrudService {
                  @Content(schema = @Schema(implementation = Policy.class)))
   @APIResponse(responseCode = "404", description = "Policy not found")
   @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
-  @Parameter(name = "id", description = "UUID of the policy", schema = @Schema(type = SchemaType.STRING))
+  @Parameter(name = "id", description = "UUID of the policy")
   public Response getPolicy(@PathParam("id") UUID policyId) {
 
     if (!user.canReadAll()) {
@@ -786,7 +786,7 @@ public class PolicyCrudService {
   @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
   @APIResponse(responseCode = "404", description = "Policy not found")
   @APIResponse(responseCode = "500", description = "Retrieval of History failed")
-  @Parameter(name = "id", description = "UUID of the policy", schema = @Schema(type = SchemaType.STRING))
+  @Parameter(name = "id", description = "UUID of the policy")
   @GET
   @Path("/{id}/history/trigger")
   public Response getTriggerHistoryForPolicy(@PathParam("id") UUID policyId) {

--- a/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
@@ -498,6 +498,48 @@ class RestApiTest extends AbstractITest {
   }
 
   @Test
+  void getOnePolicyHistory() {
+    TestPolicy tp = new TestPolicy();
+    tp.actions = "EMAIL";
+    tp.conditions = "cores = 2";
+    tp.name = "test1";
+    // Use an explicit ID; that the mock server knows
+    String uuid = "8671900e-9d31-47bf-9249-8f45698ede72";
+    uuidHelper.storeUUIDString(uuid);
+
+    given()
+        .header(authHeader)
+        .contentType(ContentType.JSON)
+        .body(tp)
+        .queryParam("alsoStore", "true")
+      .when()
+        .post(API_BASE_V1_0 + "/policies")
+      .then()
+        .statusCode(201);
+
+    ExtractableResponse<Response> er =
+    given()
+        .header(authHeader)
+        .contentType(ContentType.JSON)
+      .when()
+        .get(API_BASE_V1_0 + "/policies/8671900e-9d31-47bf-9249-8f45698ede72/history/trigger")
+      .then()
+        .statusCode(200)
+      .extract();
+
+    List returnedBody = er.body().as(List.class);
+    try {
+      Assert.assertEquals(2, returnedBody.size());
+      Map<String, Object> map = (Map<String, Object>) returnedBody.get(0);
+      Assert.assertEquals("VM 22", map.get("hostName"));
+      Assert.assertEquals("d4039530-4e3c-dead-beef-44de55400c2b", map.get("id"));
+    }
+    finally {
+      deletePolicyById(uuid);
+    }
+  }
+
+  @Test
   void storeNewEmptyPolicy() {
 
     given()

--- a/src/test/java/com/redhat/cloud/policies/app/TestLifecycleManager.java
+++ b/src/test/java/com/redhat/cloud/policies/app/TestLifecycleManager.java
@@ -133,6 +133,8 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
                      .withBody("{ \"errorMessage\" : \"something went wrong\" }")
         );
 
+    // -------------------------------
+
     List<Trigger> triggers = new ArrayList<>();
     Trigger trigger = new Trigger();
     trigger.id = "bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c";
@@ -168,6 +170,25 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
             .withBody(JsonBody.json(triggers))
         );
 
+    // -------------------------------
+
+    String alertsHistory = HeaderHelperTest.getStringFromFile("alerts-history.json",false);
+    mockServerClient
+        .when(request()
+            .withPath("/hawkular/alerts")
+            .withQueryStringParameter("triggerIds","8671900e-9d31-47bf-9249-8f45698ede72")
+            .withHeader("Hawkular-Tenant","1234")
+            .withMethod("GET")
+        )
+        .respond(response()
+            .withStatusCode(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody(JsonBody.json(alertsHistory))
+        );
+
+
+
+    // -------------------------------
 
     FullTrigger ft = new FullTrigger();
     ft.trigger.id = "00000000-0000-0000-0000-000000000001";

--- a/src/test/resources/alerts-history.json
+++ b/src/test/resources/alerts-history.json
@@ -1,0 +1,514 @@
+[
+  {
+    "eventType": "ALERT",
+    "tenantId": "1234",
+    "id": "8671900e-9d31-47bf-9249-8f45698ede72-1590506004210-7fafe5bf-dd11-4a9b-a586-b80cbf368c77",
+    "ctime": 1590506004210,
+    "dataSource": "_none_",
+    "dataId": "8671900e-9d31-47bf-9249-8f45698ede72",
+    "category": "ALERT",
+    "text": "lala",
+    "trigger": {
+      "tenantId": "901578",
+      "id": "8671900e-9d31-47bf-9249-8f45698ede72",
+      "name": "lala",
+      "type": "STANDARD",
+      "eventType": "ALERT",
+      "eventCategory": null,
+      "eventText": null,
+      "severity": "MEDIUM",
+      "autoDisable": false,
+      "autoEnable": false,
+      "autoResolve": false,
+      "autoResolveAlerts": false,
+      "autoResolveMatch": "ALL",
+      "enabled": true,
+      "firingMatch": "ALL",
+      "source": "_none_",
+      "lifecycle": [
+        {
+          "status": "CREATED",
+          "stime": 1590504135790
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504245602
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504245776
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504245931
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504246155
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504246281
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504246837
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247082
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247137
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247191
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247257
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003440
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003522
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003575
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003693
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003771
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003817
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003863
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003905
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003997
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506004210
+        }
+      ]
+    },
+    "dampening": {
+      "tenantId": "1234",
+      "triggerId": "8671900e-9d31-47bf-9249-8f45698ede72",
+      "triggerMode": "FIRING",
+      "type": "STRICT",
+      "evalTrueSetting": 1,
+      "evalTotalSetting": 1,
+      "evalTimeSetting": 0,
+      "dampeningId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING"
+    },
+    "evalSets": [
+      [
+        {
+          "evalTimestamp": 1590506003997,
+          "dataTimestamp": 1590506001593,
+          "type": "EVENT",
+          "context": {
+            "insights_id": "d4039530-4e3c-dead-beef-44de55400c2b"
+          },
+          "displayString": "Event: platform.inventory.host-egress[Event [tenantId=1234, id=0cd64d10-8c64-4fc6-b92e-f229c9f90985, ctime=1590506001593, category=insight_report, dataId=platform.inventory.host-egress, dataSource=_none_, text=host-egress report d4039530-4e3c-dead-beef-44de55400c2b for VM 22, context={insights_id=d4039530-4e3c-dead-beef-44de55400c2b}, tags={display_name=VM 22}, trigger=null]] matches [facts.arch = \"x86_64\"]",
+          "condition": {
+            "tenantId": "1234",
+            "triggerId": "8671900e-9d31-47bf-9249-8f45698ede72",
+            "triggerMode": "FIRING",
+            "type": "EVENT",
+            "conditionSetSize": 1,
+            "conditionSetIndex": 1,
+            "conditionId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING-1-1",
+            "displayString": "platform.inventory.host-egress matches [facts.arch = \"x86_64\"]",
+            "lastEvaluation": 1590506003998,
+            "dataId": "platform.inventory.host-egress",
+            "expression": "facts.arch = \"x86_64\""
+          },
+          "value": {
+            "eventType": "EVENT",
+            "tenantId": "1234",
+            "id": "0cd64d10-8c64-4fc6-b92e-f229c9f90985",
+            "ctime": 1590506001593,
+            "dataSource": "_none_",
+            "dataId": "platform.inventory.host-egress",
+            "category": "insight_report",
+            "text": "host-egress report d4039530-4e3c-dead-beef-44de55400c2b for VM 22",
+            "context": {
+              "insights_id": "d4039530-4e3c-dead-beef-44de55400c2b"
+            },
+            "tags": {
+              "display_name": "VM 22"
+            },
+            "facts": {
+              "arch": "x86_64",
+              "bios_release_date": "string",
+              "bios_vendor": "string",
+              "bios_version": "string",
+              "cloud_provider": "string",
+              "cores_per_socket": 2,
+              "cpu_flags": [
+                "string"
+              ],
+              "disk_devices": [
+                {
+                  "device": "/dev/fdd0",
+                  "label": "string",
+                  "mount_point": "/mnt/remote_nfs_shares",
+                  "options": {
+                    "ro": true,
+                    "uid": "0"
+                  },
+                  "type": "ext3"
+                }
+              ],
+              "enabled_services": [
+                "string"
+              ],
+              "infrastructure_type": "string",
+              "infrastructure_vendor": "string",
+              "insights_client_version": "string",
+              "insights_egg_version": "string",
+              "installed_packages": [
+                "0:krb5-libs-1.16.1-23.fc29.i686"
+              ],
+              "installed_products": [
+                {
+                  "id": "71",
+                  "name": "string",
+                  "status": "Subscribed"
+                }
+              ],
+              "installed_services": [
+                "string"
+              ],
+              "katello_agent_running": true,
+              "kernel_modules": [
+                "string"
+              ],
+              "last_boot_time": "2019-11-20T14:42:38.905Z",
+              "network_interfaces": {
+                "eth0": {
+                  "ipv4_addresses": [
+                    "198.51.100.42"
+                  ],
+                  "ipv6_addresses": [
+                    "2001:0db8:5b96:0000:0000:426f:8e17:642a"
+                  ],
+                  "mac_address": "20:00:00:00:00:02",
+                  "mtu": 0,
+                  "name": "eth0",
+                  "state": "UP",
+                  "type": "ether"
+                }
+              },
+              "number_of_cpus": 2,
+              "number_of_sockets": 2,
+              "os_kernel_version": "string",
+              "os_release": "string",
+              "running_processes": [
+                "string"
+              ],
+              "satellite_managed": true,
+              "subscription_auto_attach": "string",
+              "subscription_status": "string",
+              "system_memory_bytes": 0,
+              "yum_repos": {
+                "string": {
+                  "baseurl": "string",
+                  "enabled": true,
+                  "gpgcheck": true,
+                  "name": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    ],
+    "severity": "MEDIUM",
+    "status": "OPEN",
+    "lifecycle": [
+      {
+        "status": "OPEN",
+        "stime": 1590506004210
+      }
+    ]
+  },
+  {
+    "eventType": "ALERT",
+    "tenantId": "1234",
+    "id": "8671900e-9d31-47bf-9249-8f45698ede72-1590506003997-07b5f744-80cf-4de9-baa0-ef2792f07198",
+    "ctime": 1590506003997,
+    "dataSource": "_none_",
+    "dataId": "8671900e-9d31-47bf-9249-8f45698ede72",
+    "category": "ALERT",
+    "text": "lala",
+    "trigger": {
+      "tenantId": "1234",
+      "id": "8671900e-9d31-47bf-9249-8f45698ede72",
+      "name": "lala",
+      "type": "STANDARD",
+      "eventType": "ALERT",
+      "eventCategory": null,
+      "eventText": null,
+      "severity": "MEDIUM",
+      "autoDisable": false,
+      "autoEnable": false,
+      "autoResolve": false,
+      "autoResolveAlerts": false,
+      "autoResolveMatch": "ALL",
+      "enabled": true,
+      "firingMatch": "ALL",
+      "source": "_none_",
+      "lifecycle": [
+        {
+          "status": "CREATED",
+          "stime": 1590504135790
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504245602
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504245776
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504245931
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504246155
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504246281
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504246837
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247082
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247137
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247191
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590504247257
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003440
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003522
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003575
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003693
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003771
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003817
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003863
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003905
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506003997
+        },
+        {
+          "status": "ALERT_GENERATE",
+          "stime": 1590506004210
+        }
+      ]
+    },
+    "dampening": {
+      "tenantId": "1234",
+      "triggerId": "8671900e-9d31-47bf-9249-8f45698ede72",
+      "triggerMode": "FIRING",
+      "type": "STRICT",
+      "evalTrueSetting": 1,
+      "evalTotalSetting": 1,
+      "evalTimeSetting": 0,
+      "dampeningId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING"
+    },
+    "evalSets": [
+      [
+        {
+          "evalTimestamp": 1590506003906,
+          "dataTimestamp": 1590506001553,
+          "type": "EVENT",
+          "context": {
+            "insights_id": "d4039530-4e3c-dead-beef-44de55400c2b"
+          },
+          "displayString": "Event: platform.inventory.host-egress[Event [tenantId=1234, id=3f9200d6-6117-43c1-bd2b-b8eacae0d9a3, ctime=1590506001553, category=insight_report, dataId=platform.inventory.host-egress, dataSource=_none_, text=host-egress report d4039530-4e3c-dead-beef-44de55400c2b for VM 22, context={insights_id=d4039530-4e3c-dead-beef-44de55400c2b}, tags={display_name=VM 22}, trigger=null]] matches [facts.arch = \"x86_64\"]",
+          "condition": {
+            "tenantId": "1234",
+            "triggerId": "8671900e-9d31-47bf-9249-8f45698ede72",
+            "triggerMode": "FIRING",
+            "type": "EVENT",
+            "conditionSetSize": 1,
+            "conditionSetIndex": 1,
+            "conditionId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING-1-1",
+            "displayString": "platform.inventory.host-egress matches [facts.arch = \"x86_64\"]",
+            "lastEvaluation": 1590506003998,
+            "dataId": "platform.inventory.host-egress",
+            "expression": "facts.arch = \"x86_64\""
+          },
+          "value": {
+            "eventType": "EVENT",
+            "tenantId": "1234",
+            "id": "3f9200d6-6117-43c1-bd2b-b8eacae0d9a3",
+            "ctime": 1590506001553,
+            "dataSource": "_none_",
+            "dataId": "platform.inventory.host-egress",
+            "category": "insight_report",
+            "text": "host-egress report d4039530-4e3c-dead-beef-44de55400c2b for VM 22",
+            "context": {
+              "insights_id": "d4039530-4e3c-dead-beef-44de55400c2b"
+            },
+            "tags": {
+              "display_name": "VM 22"
+            },
+            "facts": {
+              "arch": "x86_64",
+              "bios_release_date": "string",
+              "bios_vendor": "string",
+              "bios_version": "string",
+              "cloud_provider": "string",
+              "cores_per_socket": 2,
+              "cpu_flags": [
+                "string"
+              ],
+              "disk_devices": [
+                {
+                  "device": "/dev/fdd0",
+                  "label": "string",
+                  "mount_point": "/mnt/remote_nfs_shares",
+                  "options": {
+                    "ro": true,
+                    "uid": "0"
+                  },
+                  "type": "ext3"
+                }
+              ],
+              "enabled_services": [
+                "string"
+              ],
+              "infrastructure_type": "string",
+              "infrastructure_vendor": "string",
+              "insights_client_version": "string",
+              "insights_egg_version": "string",
+              "installed_packages": [
+                "0:krb5-libs-1.16.1-23.fc29.i686"
+              ],
+              "installed_products": [
+                {
+                  "id": "71",
+                  "name": "string",
+                  "status": "Subscribed"
+                }
+              ],
+              "installed_services": [
+                "string"
+              ],
+              "katello_agent_running": true,
+              "kernel_modules": [
+                "string"
+              ],
+              "last_boot_time": "2019-11-20T14:42:38.905Z",
+              "network_interfaces": {
+                "eth0": {
+                  "ipv4_addresses": [
+                    "198.51.100.42"
+                  ],
+                  "ipv6_addresses": [
+                    "2001:0db8:5b96:0000:0000:426f:8e17:642a"
+                  ],
+                  "mac_address": "20:00:00:00:00:02",
+                  "mtu": 0,
+                  "name": "eth0",
+                  "state": "UP",
+                  "type": "ether"
+                }
+              },
+              "number_of_cpus": 2,
+              "number_of_sockets": 2,
+              "os_kernel_version": "string",
+              "os_release": "string",
+              "running_processes": [
+                "string"
+              ],
+              "satellite_managed": true,
+              "subscription_auto_attach": "string",
+              "subscription_status": "string",
+              "system_memory_bytes": 0,
+              "yum_repos": {
+                "string": {
+                  "baseurl": "string",
+                  "enabled": true,
+                  "gpgcheck": true,
+                  "name": "string"
+                }
+              }
+            }
+          }
+        }
+      ]
+    ],
+    "severity": "MEDIUM",
+    "status": "OPEN",
+    "lifecycle": [
+      {
+        "status": "OPEN",
+        "stime": 1590506003997
+      }
+    ]
+  }
+]

--- a/src/test/resources/alerts-history.json
+++ b/src/test/resources/alerts-history.json
@@ -120,7 +120,7 @@
       "evalTrueSetting": 1,
       "evalTotalSetting": 1,
       "evalTimeSetting": 0,
-      "dampeningId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING"
+      "dampeningId": "1234-8671900e-9d31-47bf-9249-8f45698ede72-FIRING"
     },
     "evalSets": [
       [
@@ -139,7 +139,7 @@
             "type": "EVENT",
             "conditionSetSize": 1,
             "conditionSetIndex": 1,
-            "conditionId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING-1-1",
+            "conditionId": "1234-8671900e-9d31-47bf-9249-8f45698ede72-FIRING-1-1",
             "displayString": "platform.inventory.host-egress matches [facts.arch = \"x86_64\"]",
             "lastEvaluation": 1590506003998,
             "dataId": "platform.inventory.host-egress",
@@ -213,9 +213,9 @@
                     "198.51.100.42"
                   ],
                   "ipv6_addresses": [
-                    "2001:0db8:5b96:0000:0000:426f:8e17:642a"
+                    "2001:0db8:5b96:0000:0000:0000:8e17:0000"
                   ],
-                  "mac_address": "20:00:00:00:00:02",
+                  "mac_address": "20:00:00:00:00:00",
                   "mtu": 0,
                   "name": "eth0",
                   "state": "UP",
@@ -376,7 +376,7 @@
       "evalTrueSetting": 1,
       "evalTotalSetting": 1,
       "evalTimeSetting": 0,
-      "dampeningId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING"
+      "dampeningId": "1234-8671900e-9d31-47bf-9249-8f45698ede72-FIRING"
     },
     "evalSets": [
       [
@@ -395,7 +395,7 @@
             "type": "EVENT",
             "conditionSetSize": 1,
             "conditionSetIndex": 1,
-            "conditionId": "901578-8671900e-9d31-47bf-9249-8f45698ede72-FIRING-1-1",
+            "conditionId": "1234-8671900e-9d31-47bf-9249-8f45698ede72-FIRING-1-1",
             "displayString": "platform.inventory.host-egress matches [facts.arch = \"x86_64\"]",
             "lastEvaluation": 1590506003998,
             "dataId": "platform.inventory.host-egress",


### PR DESCRIPTION
Signed-off-by: Heiko W. Rupp <hrupp@redhat.com>

```
$ curl -i -Hx-rh-identity:`cat rhid.txt` http://localhost:8080/api/policies/v1.0/policies/8671900e-9d31-47bf-9249-8f45698ede72/history/trigger
HTTP/1.1 200 OK
Content-Length: 1711
Content-Type: application/json

[{"ctime":1590506001593,"hostName":"VM 22","id":"d4039530-4e3c-dead-beef-44de55400c2b"},
  {"ctime":1590506001553,"hostName":"VM 22","id":"d4039530-4e3c-dead-beef-44de55400c2b"},
  {"ctime":1590506001551,"hostName":"VM 22","id":"d4039530-4e3c-dead-beef-44de55400c2b"},
  {"ctime":1590506001551,"hostName":"VM 22","id":"d4039530-4e3c-dead-beef-44de55400c2b"},
 {"ctime":1590506001550,"hostName":"VM 22","id":"d4039530-4e3c-dead-beef-44de55400c2b"}]
```