### PR TITLE
Use inventory_id instead of insights_id for the trigger history

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -808,9 +808,8 @@ public class PolicyCrudService {
           List<Map<String,Object>> list = jp.read("$.[*].evalSets..value");
          for (Map<String,Object> value : list) {
            long ctime = (long) value.get("ctime");
-           Map<String,Object> tmp = (Map<String, Object>) value.get("context");
-           String insights_id = (String) tmp.get("insights_id");
-           tmp = (Map<String, Object>) value.get("tags");
+           Map<String,Object> tmp = (Map<String, Object>) value.get("tags");
+           String insights_id = (String) tmp.get("inventory_id");
            String name = (String) tmp.get("display_name");
            HistoryItem hi = new HistoryItem(ctime,insights_id,name);
            items.add(hi);

--- a/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
@@ -532,7 +532,7 @@ class RestApiTest extends AbstractITest {
       Assert.assertEquals(2, returnedBody.size());
       Map<String, Object> map = (Map<String, Object>) returnedBody.get(0);
       Assert.assertEquals("VM 22", map.get("hostName"));
-      Assert.assertEquals("d4039530-4e3c-dead-beef-44de55400c2b", map.get("id"));
+      Assert.assertEquals("dce4760b-d796-48f0-a7b9-7a07a6a45d1d", map.get("id"));
     }
     finally {
       deletePolicyById(uuid);

--- a/src/test/resources/alerts-history.json
+++ b/src/test/resources/alerts-history.json
@@ -158,7 +158,8 @@
               "insights_id": "d4039530-4e3c-dead-beef-44de55400c2b"
             },
             "tags": {
-              "display_name": "VM 22"
+              "display_name": "VM 22",
+              "inventory_id": "dce4760b-d796-48f0-a7b9-7a07a6a45d1d",
             },
             "facts": {
               "arch": "x86_64",
@@ -414,7 +415,8 @@
               "insights_id": "d4039530-4e3c-dead-beef-44de55400c2b"
             },
             "tags": {
-              "display_name": "VM 22"
+              "display_name": "VM 22",
+              "inventory_id": "dce4760b-d796-48f0-a7b9-7a07a6a45d1d"
             },
             "facts": {
               "arch": "x86_64",


### PR DESCRIPTION
Using the `inventory_id` (`id` of the host used by the inventory) instead of the `insights_id`. 

Depends on https://github.com/RedHatInsights/policies-engine/pull/78 (merged)