### PR TITLE
Warn if calls to RBAC take more than 500ms. Can be turned off.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -21,13 +21,17 @@ import io.opentracing.Scope;
 import io.opentracing.Tracer;
 import io.quarkus.cache.CacheResult;
 import java.io.IOException;
+import java.util.logging.Logger;
 import javax.annotation.Priority;
+import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 import javax.ws.rs.Priorities;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
 /**
@@ -36,6 +40,8 @@ import org.eclipse.microprofile.rest.client.inject.RestClient;
 @Provider
 @Priority(Priorities.HEADER_DECORATOR +1)
 public class RbacFilter implements ContainerRequestFilter {
+
+  private final Logger log = Logger.getLogger("RbacFilter");
 
   @Inject
   Tracer tracer;
@@ -47,14 +53,23 @@ public class RbacFilter implements ContainerRequestFilter {
   @Inject
   RhIdPrincipal user;
 
+  @ConfigProperty(name = "warn.rbac.slow", defaultValue = "true")
+  Instance<Boolean> warnSlowRbac;
+
   @Override
   public void filter(ContainerRequestContext requestContext) throws IOException {
     RbacRaw result;
+    long t1 = System.currentTimeMillis();
     try (Scope ignored = tracer.buildSpan("getRBac").startActive(true)){
       result = getRbacInfo(user.getRawRhIdHeader());
     } catch (Throwable e) {
       requestContext.abortWith(Response.status(Response.Status.FORBIDDEN).build());
       return;
+    } finally {
+      long t2 = System.currentTimeMillis();
+      if (warnSlowRbac.get() && (t2 - t1) > 500) {
+        log.warning("Call to RBAC took " + (t2 - t1) + "ms");
+      }
     }
 
     user.setRbac(result.canReadAll(),result.canWriteAll());
@@ -68,9 +83,14 @@ public class RbacFilter implements ContainerRequestFilter {
    * up the user experience, as results are returned from the cache.
    * TTL of the cache items is defined in application.properties
    * quarkus.cache.caffeine.rbac-cache.expire-after-write
+   *
+   * Also it is important to Exceptions for the remote bubble out the method,
+   * as if an Exception is thrown, the cache will not store the result.
+   * Catching and returning null would end up in the next call directly
+   * return null from the cache without retrying the remote call.
    */
   @CacheResult(cacheName = "rbac-cache")
-  RbacRaw getRbacInfo(String xrhidHeader) throws Exception {
+  RbacRaw getRbacInfo(String xrhidHeader)  {
     RbacRaw result;
     result = rbac.getRbacInfo("policies", xrhidHeader);
     return result;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -49,6 +49,9 @@ mp.openapi.filter=com.redhat.cloud.policies.app.openapi.OASModifier
 # Filter health calls (hc, metrics) from access log that were successful
 accesslog.filter.health=true
 
+# Should the rback filter emit a warning when RBAC calls take > 500ms? Default is true
+warn.rbac.slow=true
+
 quarkus.jaeger.service-name=policies-api 
 quarkus.jaeger.sampler-type=const
 quarkus.jaeger.sampler-param=1


### PR DESCRIPTION
Setting the property `warn.rbac.slow` to `false` turns the warnings off.

cc @lahavyuv86