### PR TITLE
Upgrading to Quarkus 1.8.1 and adding few more types

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
     <maven.compiler.parameters>true</maven.compiler.parameters>
     <java.release>11</java.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>1.7.3.Final</quarkus.version>
+    <quarkus.version>1.8.1.Final</quarkus.version>
     <surefire-plugin.version>2.22.1</surefire-plugin.version>
 
     <version.testcontainers>1.14.3</version.testcontainers>

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -273,11 +273,6 @@ public class PolicyCrudService {
     return PagingUtils.responseBuilder(page).build();
   }
 
-  private static class ResponseListOfUUIDS {
-    List<UUID> uuids;
-    private ResponseListOfUUIDS(List<UUID> uuids) { this.uuids=uuids;}
-  }
-
   @Operation(summary = "Return all policy ids for a given account after applying the filters")
   @GET
   @Path("/ids")
@@ -336,7 +331,7 @@ public class PolicyCrudService {
   @APIResponse(responseCode = "404", description = "No policies found for customer")
   @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
   @APIResponse(responseCode = "200", description = "PolicyIds found", content =
-                 @Content(schema = @Schema(implementation = ResponseListOfUUIDS.class)))
+                 @Content(schema = @Schema(type = SchemaType.ARRAY, implementation = UUID.class)))
   public Response getPolicyIdsForCustomer() {
 
     if (!user.canReadAll()) {
@@ -576,7 +571,12 @@ public class PolicyCrudService {
 
   @Operation(summary = "Enable/disable policies identified by list of uuid in body")
   @Parameter(name = "uuids", schema = @Schema(type = SchemaType.ARRAY, implementation = UUID.class))
-  @APIResponse(responseCode = "200", description = "Policy updated")
+  @APIResponse(responseCode = "200", description = "Policy updated", content = @Content(
+          schema = @Schema(
+                  type = SchemaType.ARRAY,
+                  implementation = UUID.class
+          )
+  ))
   @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
   @POST
   @Path("/ids/enabled")
@@ -700,8 +700,8 @@ public class PolicyCrudService {
   @POST
   @Path("/validate")
   @APIResponses({
-          @APIResponse(responseCode = "200", description = "Condition validated"),
-          @APIResponse(responseCode = "400", description = "No policy provided or condition not valid"),
+          @APIResponse(responseCode = "200", description = "Condition validated", content = @Content( schema = @Schema (implementation = Msg.class))),
+          @APIResponse(responseCode = "400", description = "No policy provided or condition not valid", content = @Content( schema = @Schema (implementation = Msg.class))),
           @APIResponse(responseCode = "500", description = "Internal error")
   })
   public Response validateCondition(@Valid @NotNull Policy policy) {
@@ -732,9 +732,9 @@ public class PolicyCrudService {
   @Path("/validate-name")
   @RequestBody(content = { @Content( schema = @Schema( type = SchemaType.STRING )) })
   @APIResponses({
-          @APIResponse(responseCode = "200", description = "Name validated"),
-          @APIResponse(responseCode = "400", description = "Policy validation failed"),
-          @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action"),
+          @APIResponse(responseCode = "200", description = "Name validated", content = @Content( schema = @Schema (implementation = Msg.class))),
+          @APIResponse(responseCode = "400", description = "Policy validation failed", content = @Content( schema = @Schema (implementation = Msg.class))),
+          @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action", content = @Content( schema = @Schema (implementation = Msg.class))),
           @APIResponse(responseCode = "409", description = "Name not unique"),
           @APIResponse(responseCode = "500", description = "Internal error")
   })
@@ -773,7 +773,7 @@ public class PolicyCrudService {
   @APIResponse(responseCode = "200", description = "Policy found", content =
                  @Content(schema = @Schema(implementation = Policy.class)))
   @APIResponse(responseCode = "404", description = "Policy not found")
-  @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action")
+  @APIResponse(responseCode = "403", description = "Individual permissions missing to complete action", content = @Content( schema = @Schema (implementation = Msg.class)))
   @Parameter(name = "id", description = "UUID of the policy")
   public Response getPolicy(@PathParam("id") UUID policyId) {
 

--- a/src/test/java/com/redhat/cloud/policies/app/OapiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/OapiTest.java
@@ -75,7 +75,7 @@ public class OapiTest extends AbstractITest {
 
 		// Check that all properties are present ( https://github.com/smallrye/smallrye-open-api/issues/437 )
 		Map<String, Schema> policyProperties = schemas.get("Policy").getProperties();
-		Assert.assertEquals(11, policyProperties.size());
+		Assert.assertEquals(9, policyProperties.size());
 		Assert.assertTrue(policyProperties.containsKey("ctime"));
 		Assert.assertTrue(policyProperties.containsKey("mtime"));
 


### PR DESCRIPTION
The quarkus upgrade removes from the openapi the EntityManager related fields.