### PR TITLE
POL-363 Don't sort the trigger history by id.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -1034,10 +1034,16 @@ public class PolicyCrudService {
 
   private String getSortFromPageColumn(Sort.Column column) {
     String sort = column.getName();
-    if ("name".equals(sort)) {
-      sort = "tags.display_name";
-    } else {
-      sort = "ctime";
+    switch (sort) {
+      case "name":
+        sort = "tags.display_name";
+        break;
+      case "ctime":
+      case "mtime":
+        sort = "ctime";
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown sort column: " + sort);
     }
     return sort;
   }

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -886,9 +886,9 @@ public class PolicyCrudService {
                       type = SchemaType.STRING,
                       enumeration = {
                               "hostName",
-                              "id",
                               "ctime"
-                      }
+                      },
+                      defaultValue = "ctime"
               )
       ),
       @Parameter(
@@ -923,7 +923,7 @@ public class PolicyCrudService {
          Pager pager = PagingUtils.extractPager(uriInfo);
 
          int limit = pager.getLimit();
-         // We dont allow unlimited or values > 200
+         // We don't allow unlimited or values > 200
          limit = limit == Pager.NO_LIMIT ? 50 :  min(limit,200);
          int pageNum = pager.getOffset() / limit;
 
@@ -1034,13 +1034,10 @@ public class PolicyCrudService {
 
   private String getSortFromPageColumn(Sort.Column column) {
     String sort = column.getName();
-    switch (sort) {
-      case "id":
-        sort = "tags.inventory_id"; break;
-      case "name":
-        sort = "tags.display_name"; break;
-      default:
-        sort = "ctime";
+    if ("name".equals(sort)) {
+      sort = "tags.display_name";
+    } else {
+      sort = "ctime";
     }
     return sort;
   }

--- a/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
@@ -642,6 +642,23 @@ class RestApiTest extends AbstractITest {
       deletePolicyById(uuid);
     }
   }
+  @Test
+  void getOnePolicyHistoryBadSort() {
+    String uuid = setupPolicyForHistory();
+
+    try {
+      given()
+          .header(authHeader)
+          .contentType(ContentType.JSON)
+          .when()
+          .get(API_BASE_V1_0 + "/policies/8671900e-9d31-47bf-9249-8f45698ede72/history/trigger?sortColumn=id")
+          .then()
+          .statusCode(400);
+    }
+    finally {
+      deletePolicyById(uuid);
+    }
+  }
 
   @Test
   void getOnePolicyHistoryFilterByName() {


### PR DESCRIPTION
As previously discussed.
Question: should we silently do this. Or return some 400 for 'unknown sort field'?
The latter makes it probably more obvious for customers.