### PR TITLE
Start of an admin endpoint at /admin.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/JaxRsApplication.java
+++ b/src/main/java/com/redhat/cloud/policies/app/JaxRsApplication.java
@@ -31,7 +31,7 @@ import java.util.logging.Logger;
  * @author hrupp
  *
  */
-@ApplicationPath("/api/policies/v1.0")
+@ApplicationPath("/")
 public class JaxRsApplication extends Application {
 
   Logger log = Logger.getLogger("Policies UI-Backend");
@@ -48,7 +48,7 @@ public class JaxRsApplication extends Application {
     showVersionInfo();
 
     // Generate a token
-    TokenHolder.getInstance();
+    StuffHolder.getInstance();
   }
 
   private void showVersionInfo() {

--- a/src/main/java/com/redhat/cloud/policies/app/StuffHolder.java
+++ b/src/main/java/com/redhat/cloud/policies/app/StuffHolder.java
@@ -21,14 +21,17 @@ import java.util.UUID;
 /**
  * @author hrupp
  */
-public class TokenHolder {
+public class StuffHolder {
 
-  private static TokenHolder tokenHolder;
+  private static StuffHolder tokenHolder;
 
-  private String token;
+  private final String token;
+  private boolean adminDown;
+  private boolean degraded;
 
-  private TokenHolder() {
+  private StuffHolder() {
     token = UUID.randomUUID().toString();
+    adminDown = false;
     System.out.println("Token: " + token);
   }
 
@@ -36,10 +39,26 @@ public class TokenHolder {
     return token.equals(input);
   }
 
-  public static TokenHolder getInstance() {
+  public static StuffHolder getInstance() {
     if (tokenHolder==null) {
-      tokenHolder = new TokenHolder();
+      tokenHolder = new StuffHolder();
     }
     return tokenHolder;
+  }
+
+  public boolean isAdminDown() {
+    return adminDown;
+  }
+
+  public void setAdminDown(boolean status) {
+    this.adminDown = status;
+  }
+
+  public boolean isDegraded() {
+    return degraded;
+  }
+
+  public void setDegraded(boolean degraded) {
+    this.degraded = degraded;
   }
 }

--- a/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
@@ -77,7 +77,7 @@ public class IncomingRequestFilter implements ContainerRequestFilter {
 
     // The following are available to everyone
     if (normalisedPath.endsWith("openapi.json") ||
-        normalisedPath.startsWith("/status") ||
+        normalisedPath.equals("/api/policies/v1.0/status") ||
         normalisedPath.startsWith("/admin")
     ) {
       return; // We are done here

--- a/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
@@ -77,6 +77,7 @@ public class IncomingRequestFilter implements ContainerRequestFilter {
 
     // The following are available to everyone
     if (normalisedPath.endsWith("openapi.json") ||
+        normalisedPath.startsWith("/status") ||
         normalisedPath.startsWith("/admin")
     ) {
       return; // We are done here

--- a/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
@@ -74,8 +74,12 @@ public class IncomingRequestFilter implements ContainerRequestFilter {
     RoutingContext routingContext = request().getCurrent();
 
     String normalisedPath = routingContext.normalisedPath();
-    if (normalisedPath.endsWith("openapi.json") || normalisedPath.equals("/api/policies/v1.0/status")) {
-      return;
+
+    // The following are available to everyone
+    if (normalisedPath.endsWith("openapi.json") ||
+        normalisedPath.startsWith("/admin")
+    ) {
+      return; // We are done here
     }
 
     String xrhid_header = requestContext.getHeaderString("x-rh-identity");

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -62,7 +62,7 @@ public class RbacFilter implements ContainerRequestFilter {
   public void filter(ContainerRequestContext requestContext) throws IOException {
     RbacRaw result;
 
-    if (requestContext.getUriInfo().getPath(true).equals("/status")) {
+    if (requestContext.getUriInfo().getPath(true).startsWith("/admin")) {
       return;
     }
 

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -31,10 +31,8 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
-import io.quarkus.resteasy.runtime.standalone.VertxHttpRequest;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-import org.jboss.resteasy.core.interception.jaxrs.PostMatchContainerRequestContext;
 
 /**
  * @author hrupp
@@ -62,7 +60,8 @@ public class RbacFilter implements ContainerRequestFilter {
   public void filter(ContainerRequestContext requestContext) throws IOException {
     RbacRaw result;
 
-    if (requestContext.getUriInfo().getPath(true).startsWith("/admin")) {
+    String path = requestContext.getUriInfo().getPath(true);
+    if (path.startsWith("/admin") || path.startsWith("/status")) {
       return;
     }
 

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -61,7 +61,7 @@ public class RbacFilter implements ContainerRequestFilter {
     RbacRaw result;
 
     String path = requestContext.getUriInfo().getPath(true);
-    if (path.startsWith("/admin") || path.startsWith("/status")) {
+    if (path.startsWith("/admin") || path.equals("/api/policies/v1.0/status")) {
       return;
     }
 

--- a/src/main/java/com/redhat/cloud/policies/app/health/AbstractHealthCheck.java
+++ b/src/main/java/com/redhat/cloud/policies/app/health/AbstractHealthCheck.java
@@ -16,24 +16,28 @@
  */
 package com.redhat.cloud.policies.app.health;
 
-import javax.enterprise.context.ApplicationScoped;
-import org.eclipse.microprofile.health.HealthCheck;
+import com.redhat.cloud.policies.app.StuffHolder;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
-import org.eclipse.microprofile.health.Readiness;
 
 /**
- * Health check that determines if we should receive requests.
  * @author hrupp
  */
-@ApplicationScoped
-@Readiness
-public class ReadinessProbe extends AbstractHealthCheck implements HealthCheck {
-  @Override
-  public HealthCheckResponse call() {
+public abstract class AbstractHealthCheck {
 
-    HealthCheckResponseBuilder builder = getBuilder("ready");
 
-    return builder.build();
+  HealthCheckResponseBuilder getBuilder(String name) {
+    boolean degraded = StuffHolder.getInstance().isAdminDown();
+
+    HealthCheckResponseBuilder builder = HealthCheckResponse.named(name);
+
+    if (degraded) {
+      builder.withData("status","admin-down");
+      builder.down();
+    }
+    else {
+      builder.up();
+    }
+    return builder;
   }
 }

--- a/src/main/java/com/redhat/cloud/policies/app/health/LivenessProbe.java
+++ b/src/main/java/com/redhat/cloud/policies/app/health/LivenessProbe.java
@@ -16,24 +16,27 @@
  */
 package com.redhat.cloud.policies.app.health;
 
-import javax.enterprise.context.ApplicationScoped;
 import org.eclipse.microprofile.health.HealthCheck;
 import org.eclipse.microprofile.health.HealthCheckResponse;
 import org.eclipse.microprofile.health.HealthCheckResponseBuilder;
-import org.eclipse.microprofile.health.Readiness;
+import org.eclipse.microprofile.health.Liveness;
+
+import javax.enterprise.context.ApplicationScoped;
 
 /**
- * Health check that determines if we should receive requests.
+ * Health check that defines if we are up or having issues.
  * @author hrupp
  */
 @ApplicationScoped
-@Readiness
-public class ReadinessProbe extends AbstractHealthCheck implements HealthCheck {
+@Liveness
+public class LivenessProbe extends AbstractHealthCheck implements HealthCheck {
+
+
+
   @Override
   public HealthCheckResponse call() {
 
-    HealthCheckResponseBuilder builder = getBuilder("ready");
-
+    HealthCheckResponseBuilder builder = getBuilder("live");
     return builder.build();
   }
 }

--- a/src/main/java/com/redhat/cloud/policies/app/health/StatusEndpoint.java
+++ b/src/main/java/com/redhat/cloud/policies/app/health/StatusEndpoint.java
@@ -18,6 +18,7 @@ package com.redhat.cloud.policies.app.health;
 
 import com.redhat.cloud.policies.app.NotificationSystem;
 import com.redhat.cloud.policies.app.PolicyEngine;
+import com.redhat.cloud.policies.app.StuffHolder;
 import com.redhat.cloud.policies.app.model.Policy;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 
@@ -54,6 +55,14 @@ public class StatusEndpoint {
 
     Map<String,String> issues = new HashMap<>();
 
+    // Admin has used the endpoint to signal degraded status
+    boolean degraded = StuffHolder.getInstance().isDegraded();
+    if (degraded) {
+      issues.put("admin-degraded", "true");
+    }
+
+
+    // Now the normal checks
     try {
       Policy.findByName("dummy", "-dummy-");
     }

--- a/src/main/java/com/redhat/cloud/policies/app/health/StatusEndpoint.java
+++ b/src/main/java/com/redhat/cloud/policies/app/health/StatusEndpoint.java
@@ -37,7 +37,7 @@ import java.util.Map;
  *
  * @author hrupp
  */
-@Path("/status")
+@Path("/api/policies/v1.0/status")
 @RequestScoped
 public class StatusEndpoint {
 
@@ -50,7 +50,7 @@ public class StatusEndpoint {
   NotificationSystem notifications;
 
   @GET
-  @Produces("text/plain")
+  @Produces("application/json")
   public Response getStatus() {
 
     Map<String,String> issues = new HashMap<>();

--- a/src/main/java/com/redhat/cloud/policies/app/openapi/OASModifier.java
+++ b/src/main/java/com/redhat/cloud/policies/app/openapi/OASModifier.java
@@ -44,7 +44,10 @@ public class OASModifier implements OASFilter {
       PathItem p = paths.getPathItem(key);
       String mangledName = mangleName(key);
       if (!mangledName.startsWith("/user-config") && // POL-230 this is a private api, so don't show it.
-          !mangledName.startsWith("/policies/sync")) { // POL-277 private api
+          !mangledName.startsWith("/policies/sync") &&
+          !mangledName.startsWith("/admin") &&
+          !mangledName.startsWith("/status")
+      ) { // POL-277 private api
         replacementItems.put(mangledName, p);
       }
 

--- a/src/main/java/com/redhat/cloud/policies/app/rest/AdminService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/AdminService.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app.rest;
+
+import com.redhat.cloud.policies.app.PolicyEngine;
+import com.redhat.cloud.policies.app.StuffHolder;
+import com.redhat.cloud.policies.app.model.Msg;
+import com.redhat.cloud.policies.app.model.Policy;
+import com.redhat.cloud.policies.app.model.engine.FullTrigger;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.NotFoundException;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+import java.util.Optional;
+import java.util.logging.Logger;
+import java.util.stream.Stream;
+
+/**
+ * @author hrupp
+ */
+@Path("/admin")
+@Produces("application/json")
+@Consumes("application/json")
+@RequestScoped
+public class AdminService {
+
+  private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
+
+  @Inject
+  @RestClient
+  PolicyEngine engine;
+
+  /**
+   * Signal health to outside world. Allowed values for state
+   * * 'ok': all ok
+   * * 'degraded': signal instance as degraded on status endpoint
+   * * 'admin-down': signal health-checks as down. Signals k8s to kill the pod
+   */
+  @Path("/status")
+  @POST
+  public Response setAdminDown(@QueryParam("status") Optional<String> status) {
+
+    Response.ResponseBuilder builder;
+
+    StuffHolder th = StuffHolder.getInstance();
+
+    switch (status.orElse("ok")) {
+      case "ok":
+        th.setDegraded(false);
+        th.setAdminDown(false);
+        builder = Response.ok()
+          .entity(new Msg("Reset state to ok"));
+        break;
+      case "degraded":
+        th.setDegraded(true);
+        builder = Response.ok()
+          .entity(new Msg("Set degraded state"));
+        break;
+      case "admin-down":
+        th.setAdminDown(true);
+        builder = Response.ok()
+          .entity(new Msg("Set admin down state"));
+        break;
+      default:
+        builder = Response.status(Response.Status.BAD_REQUEST)
+            .entity(new Msg("Unknown status passed"));
+    }
+
+    return builder.build();
+  }
+
+  @Path("/sync")
+  @POST
+  @Transactional
+  public Response syncToEngine(@QueryParam("token") String token) {
+
+    boolean validToken = StuffHolder.getInstance().compareToken(token);
+    if (!validToken) {
+      return Response.status(Response.Status.FORBIDDEN).entity("You don't have permission for this").build();
+    }
+
+    final int[] count = {0};
+    try (Stream<Policy> policies = Policy.streamAll()) {
+      policies.forEach(p -> {
+        FullTrigger fullTrigger;
+        try {
+          fullTrigger = engine.fetchTrigger(p.id, p.customerid);
+        }
+        catch (NotFoundException nfe) {
+          fullTrigger=null;
+        }
+        if (fullTrigger == null) { // Engine does not have the trigger
+          log.info("Trigger " + p.id + " not found, syncing");
+          FullTrigger ft = new FullTrigger(p);
+          engine.storeTrigger(ft, false, p.customerid);
+          log.info("   done");
+          count[0]++;
+        }
+        else {
+          log.info("Trigger " + p.id + " already in engine, skipping");
+        }
+      });
+    }
+    log.info("Stored " + count[0] + " triggers");
+    return Response.ok().build();
+  }
+
+}

--- a/src/main/java/com/redhat/cloud/policies/app/rest/FactService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/FactService.java
@@ -37,7 +37,7 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 /**
  * @author hrupp
  */
-@Path("/facts")
+@Path("/api/policies/v1.0/facts")
 @Produces("application/json")
 @Consumes("application/json")
 @RequestScoped

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -20,7 +20,6 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.policies.app.PolicyEngine;
-import com.redhat.cloud.policies.app.TokenHolder;
 import com.redhat.cloud.policies.app.auth.RhIdPrincipal;
 import com.redhat.cloud.policies.app.model.UUIDHelperBean;
 import com.redhat.cloud.policies.app.model.engine.FullTrigger;
@@ -38,7 +37,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
 import javax.json.JsonString;
@@ -94,7 +92,7 @@ import static java.lang.Integer.min;
 /**
  * @author hrupp
  */
-@Path("/policies")
+@Path("/api/policies/v1.0/policies")
 @Produces("application/json")
 @Consumes("application/json")
 @SimplyTimed(absolute = true, name="PolicySvc")
@@ -1082,40 +1080,5 @@ public class PolicyCrudService {
     return null;
   }
 
-  @Path("/sync")
-  @POST
-  @Transactional
-  public Response syncToEngine(@QueryParam("token") String token) {
-
-    boolean validToken = TokenHolder.getInstance().compareToken(token);
-    if (!validToken) {
-      return Response.status(Response.Status.FORBIDDEN).entity("You don't have permission for this").build();
-    }
-
-    final int[] count = {0};
-    try (Stream<Policy> policies = Policy.streamAll()) {
-      policies.forEach(p -> {
-        FullTrigger fullTrigger;
-        try {
-          fullTrigger = engine.fetchTrigger(p.id, p.customerid);
-        }
-        catch (NotFoundException nfe) {
-          fullTrigger=null;
-        }
-        if (fullTrigger == null) { // Engine does not have the trigger
-          log.info("Trigger " + p.id + " not found, syncing");
-          FullTrigger ft = new FullTrigger(p);
-          engine.storeTrigger(ft, false, p.customerid);
-          log.info("   done");
-          count[0]++;
-        }
-        else {
-          log.info("Trigger " + p.id + " already in engine, skipping");
-        }
-      });
-    }
-    log.info("Stored " + count[0] + " triggers");
-    return Response.ok().build();
-  }
 
 }

--- a/src/main/java/com/redhat/cloud/policies/app/rest/UserConfigService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/UserConfigService.java
@@ -40,14 +40,14 @@ import java.util.logging.Logger;
 /**
  * @author hrupp
  */
-@Path("/user-config")
+@Path("/api/policies/v1.0/user-config")
 @Produces("application/json")
 @Consumes("application/json")
 @SimplyTimed(absolute = true, name = "UserConfigSvc")
 @RequestScoped
 public class UserConfigService {
 
-  private Logger log = Logger.getLogger(this.getClass().getSimpleName());
+  private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
 
   @SuppressWarnings("CdiInjectionPointsInspection")
   @Inject

--- a/src/test/java/com/redhat/cloud/policies/app/HealthCheckTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/HealthCheckTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.when;
+import static io.restassured.RestAssured.with;
+
+/**
+ * @author hrupp
+ */
+@QuarkusTest
+public class HealthCheckTest {
+
+  @Test
+  void testNormalHealth() {
+    when()
+        .get("/health")
+      .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void testAdminDown() {
+
+    with()
+        .queryParam("status","admin-down")
+        .accept("application/json")
+        .contentType("application/json")
+      .when()
+        .post("/admin/status")
+      .then()
+        .statusCode(200);
+
+    try {
+      when()
+          .get("/health")
+          .then()
+          .statusCode(503);
+    }
+    finally {
+      with()
+          .queryParam("status","ok")
+          .accept("application/json")
+          .contentType("application/json")
+        .when()
+          .post("/admin/status")
+        .then()
+          .statusCode(200);
+    }
+
+  }
+}

--- a/src/test/java/com/redhat/cloud/policies/app/StatusEndpointTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/StatusEndpointTest.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.when;
+import static io.restassured.RestAssured.with;
+import static org.hamcrest.core.Is.is;
+
+/**
+ * @author hrupp
+ */
+@QuarkusTest
+public class StatusEndpointTest extends AbstractITest {
+
+  @Test
+  void getStatusSimple() {
+
+    when()
+        .get("/api/policies/v1.0/status")
+      .then()
+        .statusCode(200);
+  }
+
+  @Test
+  void getStatusDegraded() {
+
+    with()
+        .queryParam("status","degraded")
+        .accept("application/json")
+        .contentType("application/json")
+      .when()
+        .post("/admin/status")
+      .then()
+        .statusCode(200);
+
+    try {
+
+      when()
+          .get("/api/policies/v1.0/status")
+          .then()
+          .body("admin-degraded", is("true"))
+          .statusCode(500);
+    }
+    finally {
+      with()
+          .queryParam("status","ok")
+          .accept("application/json")
+          .contentType("application/json")
+        .when()
+          .post("/admin/status")
+        .then()
+          .statusCode(200);
+    }
+  }
+}

--- a/src/test/java/com/redhat/cloud/policies/app/TestLifecycleManager.java
+++ b/src/test/java/com/redhat/cloud/policies/app/TestLifecycleManager.java
@@ -265,6 +265,30 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
                      .withBody("{ \"msg\" : \"ok\" }")
         );
 
+    // ------------ status page
+    mockServerClient
+        .when(request()
+            .withPath("/hawkular/alerts/triggers")
+            .withQueryStringParameter("triggerIds","dummy")
+            .withHeader("Hawkular-Tenant","dummy")
+        )
+        .respond(response()
+            .withStatusCode(200)
+            .withHeader("Content-Type", "application/json")
+            .withBody("[]")
+        );
+
+    mockServerClient
+        .when(request()
+            .withPath("/apps")
+        )
+        .respond(response()
+            .withBody("[]")
+            .withHeader("Content-Type", "application/json")
+            .withStatusCode(200)
+        );
+
+    // ------------
 
     mockServerClient
         .when(request()


### PR DESCRIPTION
Also move the sync endpoint to /admin.
Adds a live check that can be set to fail.

```
$ curl -i -X POST    http://localhost:8080/admin/status?status=degraded
{"msg":"Set degraded state"}
$curl http://localhost:8080/status
HTTP/1.1 500 Internal Server Error
Content-Length: 287
Content-Type: text/plain;charset=UTF-8

{
  engine=RESTEASY004655: Unable ...,
 admin-degraded=true,
 notifications=Unknown error, status code 401
}

$ curl -i  http://localhost:8080/health/live
HTTP/1.1 200 OK
content-type: application/json; charset=UTF-8
content-length: 121


{
    "status": "UP",
    "checks": [
        {
            "name": "live",
            "status": "UP"
        }
    ]
}

$ curl -i -X POST    http://localhost:8080/admin/status?status=admin-down
HTTP/1.1 200 OK
Content-Length: 30
Content-Type: application/json

{"msg":"Set admin down state"}

$curl http://localhost:8080/health/live
HTTP/1.1 503 Service Unavailable
content-type: application/json; charset=UTF-8
content-length: 201


{
    "status": "DOWN",
    "checks": [
        {
            "name": "live",
            "status": "DOWN",
            "data": {
                "status": "admin-down"
            }
        }
    ]
}

```