### PR TITLE
Add a /verify endpoint to find orphaned entries.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/PolicyEngine.java
+++ b/src/main/java/com/redhat/cloud/policies/app/PolicyEngine.java
@@ -63,6 +63,11 @@ public interface PolicyEngine {
                    @HeaderParam("Hawkular-Tenant") String customerId
   );
 
+  @GET
+  @Path("/triggers")
+  @Produces("application/json")
+  List<Trigger> findTriggersForCustomer(@HeaderParam("Hawkular-Tenant") String customerId);
+
   /**
    * Update a trigger
    *


### PR DESCRIPTION
The 2nd part that looks at triggers in engine and then tries to find corresponding policies currently depends on accounts being in postgres, so that getTriggersForAccount() works. This needs to be improved going forward.