### PR TITLE
More detailed stats that show a distribution of policies per customer.

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -59,3 +59,6 @@ quarkus.jaeger.sampler-param=1
 
 # Duration rbac entries are kept in cache
 quarkus.cache.caffeine.rbac-cache.expire-after-write=PT120s
+
+# Status endpoint
+# stats.filter.cid=


### PR DESCRIPTION
Property `stats.filter.cid` can be used to  filter out certain customerIds. That is a comma separated list.

Example:

$ curl -i  http://localhost:8080/admin/stats

HTTP/1.1 200 OK
Content-Length: 188
Content-Type: application/json

{"totalPoliciesCount":28,"filteredPoliciesCount":6,"customerIdsCount":4,"customerPoliciesCount":22,"buckets":{"1":1,"2":0,"3":1,"4":0,"10+":1,"5-10":2},"filteredIdsCount":1,"totalCount":5}

