### PR TITLE
Expose status also as Gauge.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/rest/AdminService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/AdminService.java
@@ -78,7 +78,7 @@ public class AdminService {
   private static final String[] BUCKETS = {"1","2","3","4","5-10","10+"};
 
   @PostConstruct
-  private void postConstruct() {
+  void postConstruct() {
 
     if (filterIdsString.isPresent()) {
       String s = filterIdsString.get();

--- a/src/test/java/com/redhat/cloud/policies/app/StatusEndpointTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/StatusEndpointTest.java
@@ -17,6 +17,9 @@
 package com.redhat.cloud.policies.app;
 
 import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.response.Response;
+import io.restassured.response.ValidatableResponse;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import static io.restassured.RestAssured.when;
@@ -51,12 +54,22 @@ public class StatusEndpointTest extends AbstractITest {
         .statusCode(200);
 
     try {
-
       when()
           .get("/api/policies/v1.0/status")
           .then()
           .body("admin-degraded", is("true"))
           .statusCode(500);
+
+      String body =
+      when()
+          .get("/metrics/application/status_isDegraded")
+        .then()
+          .statusCode(200)
+          .extract()
+            .body().asString();
+
+      Assertions.assertTrue(body.contains("application_status_isDegraded 2.0"));
+
     }
     finally {
       with()


### PR DESCRIPTION
  If degraded, log probe results as severe.

Due to the way Quarkus initialises things, the metric is only available after the first call to the status endpoint.

```
$ curl localhost:8080/api/policies/v1.0/status
{"engine":"RESTEASY004655: Unable to invoke request: org.apache.http.conn.HttpHostConnectException: Connect to localhost:8084 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused)","notifications":"Unknown error, status code 401"}
```
Logs then:

`2020-11-11 11:12:40,595 SEVERE [StatusEndpoint] (vert.x-worker-thread-4) Status reports: engine=RESTEASY004655: Unable to invoke request: org.apache.http.conn.HttpHostConnectException: Connect to localhost:8084 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused (Connection refused); backend-db=interface javax.enterprise.context.RequestScoped; notifications=Unknown error, status code 401
`

Metric:

```
$ curl  localhost:8080/metrics/application/status_isDegraded
# HELP application_status_isDegraded Returns 0 if good, value > 0 for number of entries in the status message
# TYPE application_status_isDegraded gauge
application_status_isDegraded 3.0

```