### PR TITLE
[POL-386] Make health check fail if there is a DB connection issue

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,6 +6,13 @@ quarkus.datasource.jdbc.driver=io.opentracing.contrib.jdbc.TracingDriver
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
 quarkus.datasource.username = postgres
 quarkus.datasource.password = postgres
+# The next are to check if connections are valid.
+# We close them after 1 minute and obtain a new one
+# This way we can have the health check react to a change of the DB password.
+# See POL-386
+quarkus.datasource.jdbc.new-connection-sql=select 1;
+quarkus.datasource.jdbc.validation-query-sql=select count(*) from fact;
+quarkus.datasource.jdbc.max-lifetime=PT60s
 
 # Do DB-Migration at start
 quarkus.flyway.migrate-at-start=true


### PR DESCRIPTION
We make the pool close connections after 60s to force creating a new connection, which makes the health check react on a  changed password.

How to test: start postgres with normal credentials, start ui-backend. Then in a terminal connect to postgres and issue e.g. 
`postgres=# alter user postgres password 'pg';`
Watch quarkus console. after ~ 60sec an error message should show about bad password when talking to postgres. Then do
`$ curl -i localhost:8080/health` or `curl -i localhost:8080/health/live` which should show the status as down and give a 5xx error.

```
$ curl localhost:8080/health

{
    "status": "DOWN",
    "checks": [
        {
            "name": "live",
            "status": "UP"
        },
        {
            "name": "Database connections health check",
            "status": "DOWN",
            "data": {
                "default": "Unable to execute the validation check for the default DataSource: FATAL: password authentication failed for user \"postgres\""
            }
        },
        {
            "name": "ready",
            "status": "UP"
        }
    ]
}

```