### PR TITLE
POL-432 Rollback database changes if any error happened.

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -42,6 +42,8 @@ import javax.inject.Inject;
 import javax.json.JsonString;
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceException;
+import javax.transaction.SystemException;
+import javax.transaction.TransactionManager;
 import javax.transaction.Transactional;
 import javax.validation.ConstraintViolation;
 import javax.validation.Valid;
@@ -115,6 +117,9 @@ public class PolicyCrudService {
 
   @Inject
   EntityManager entityManager;
+
+  @Inject
+  TransactionManager transactionManager;
 
   @Inject
   UUIDHelperBean uuidHelper;
@@ -680,12 +685,17 @@ public class PolicyCrudService {
           existingTrigger.updateFromPolicy(storedPolicy);
           try {
             engine.updateTrigger(storedPolicy.id, existingTrigger, false, user.getAccount());
-            Policy.persist(storedPolicy);
           } catch (Exception e) {
+            transactionManager.setRollbackOnly();
             return Response.status(400, e.getMessage()).entity(getEngineExceptionMsg(e)).build();
           }
-          Policy.persist(storedPolicy);
         } catch (Throwable t) {
+          try {
+            transactionManager.setRollbackOnly();
+          } catch (SystemException ex) {
+            throw new RuntimeException(ex);
+          }
+
           return getResponseSavingPolicyThrowable(t);
         }
 


### PR DESCRIPTION
 - Persisted objects will save automatically, to prevent this
   a RuntimeException should happen between the Transaction or
   manually opt-in for a rollback via TransactionManager