### PR TITLE
Run `mvn install` of `mvn package` on ci

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           java-version: 11
       - name: Build with Maven
-        run: mvn package
+        run: mvn install
       - uses: actions/upload-artifact@v2
         name: Upload openapi.json
         with:


### PR DESCRIPTION
@pilhuhn I'm not really sure what changed, but with the changes in #101 `mvn package` is not running the same tests that `mvn install` does. 
I noticed because the `target/openapi.json` no longer appears when running `mvn package`.
Also, running locally, a bunch of logs appears on `install` that do not show on `package`.
