### PR TITLE
POL-450 Clean old policies history entries

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/PoliciesHistoryCleaner.java
+++ b/src/main/java/com/redhat/cloud/policies/app/PoliciesHistoryCleaner.java
@@ -1,0 +1,47 @@
+package com.redhat.cloud.policies.app;
+
+import io.quarkus.scheduler.Scheduled;
+import org.eclipse.microprofile.config.ConfigProvider;
+import org.hibernate.Session;
+import org.jboss.logging.Logger;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+import javax.transaction.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+@Singleton
+public class PoliciesHistoryCleaner {
+
+    public static final String POLICIES_HISTORY_CLEANER_DELETE_AFTER_CONF_KEY = "policies-history.cleaner.delete-after";
+
+    private static final Logger LOGGER = Logger.getLogger(PoliciesHistoryCleaner.class);
+    private static final Duration DEFAULT_DELETE_DELAY = Duration.ofDays(14L);
+
+    @Inject
+    Session session;
+
+    /**
+     * The policies UI shows a retention time for policies history entries.
+     * This scheduled job deletes from the database the history entries which are older than that retention time.
+     */
+    /*
+     * TODO The scheduling is delayed to prevent an unwanted execution during tests. Remove the delay and set the period
+     * to `disabled` after the Quarkus 2 bump. See https://quarkus.io/guides/scheduler-reference for more details.
+     */
+    @Scheduled(identity = "PoliciesHistoryCleaner", delay = 10L, delayUnit = MINUTES, every = "{policies-history.cleaner.period}")
+    @Transactional
+    public void clean() {
+        Duration deleteDelay = ConfigProvider.getConfig().getOptionalValue(POLICIES_HISTORY_CLEANER_DELETE_AFTER_CONF_KEY, Duration.class)
+                .orElse(DEFAULT_DELETE_DELAY);
+        Instant deleteBefore = Instant.now().minus(deleteDelay);
+        LOGGER.debugf("Policies history purge starting. Entries older than %s will be deleted.", deleteBefore.toString());
+        int deleted = session.createQuery("DELETE FROM PoliciesHistoryEntry WHERE ctime < :ctime")
+                .setParameter("ctime", deleteBefore.toEpochMilli())
+                .executeUpdate();
+        LOGGER.debugf("Policies history purge ended. %d entries were deleted from the database.", deleted);
+    }
+}

--- a/src/main/java/com/redhat/cloud/policies/app/PoliciesHistoryCleaner.java
+++ b/src/main/java/com/redhat/cloud/policies/app/PoliciesHistoryCleaner.java
@@ -38,10 +38,10 @@ public class PoliciesHistoryCleaner {
         Duration deleteDelay = ConfigProvider.getConfig().getOptionalValue(POLICIES_HISTORY_CLEANER_DELETE_AFTER_CONF_KEY, Duration.class)
                 .orElse(DEFAULT_DELETE_DELAY);
         Instant deleteBefore = Instant.now().minus(deleteDelay);
-        LOGGER.debugf("Policies history purge starting. Entries older than %s will be deleted.", deleteBefore.toString());
+        LOGGER.infof("Policies history purge starting. Entries older than %s will be deleted.", deleteBefore.toString());
         int deleted = session.createQuery("DELETE FROM PoliciesHistoryEntry WHERE ctime < :ctime")
                 .setParameter("ctime", deleteBefore.toEpochMilli())
                 .executeUpdate();
-        LOGGER.debugf("Policies history purge ended. %d entries were deleted from the database.", deleted);
+        LOGGER.infof("Policies history purge ended. %d entries were deleted from the database.", deleted);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -90,5 +90,3 @@ policies-history.enabled=false
 
 # Period between two policies history cleanings. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
 policies-history.cleaner.period=P1D
-
-%test.quarkus.log.category."com.redhat.cloud.policies.app.PoliciesHistoryCleaner".level=DEBUG

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -87,3 +87,8 @@ quarkus.log.cloudwatch.access-key-secret=placeholder
 
 # If true, the following property will enable policies history retrieval from the database.
 policies-history.enabled=false
+
+# Period between two policies history cleanings. It must be expressed with the ISO-8601 duration format PnDTnHnMn.nS.
+policies-history.cleaner.period=P1D
+
+%test.quarkus.log.category."com.redhat.cloud.policies.app.PoliciesHistoryCleaner".level=DEBUG

--- a/src/test/java/com/redhat/cloud/policies/app/PoliciesHistoryCleanerTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/PoliciesHistoryCleanerTest.java
@@ -1,0 +1,73 @@
+package com.redhat.cloud.policies.app;
+
+import com.redhat.cloud.policies.app.model.history.PoliciesHistoryEntry;
+import io.quarkus.test.TestTransaction;
+import io.quarkus.test.common.QuarkusTestResource;
+import io.quarkus.test.junit.QuarkusTest;
+import org.hibernate.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import javax.inject.Inject;
+import javax.transaction.Transactional;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.UUID;
+
+import static com.redhat.cloud.policies.app.PoliciesHistoryCleaner.POLICIES_HISTORY_CLEANER_DELETE_AFTER_CONF_KEY;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@QuarkusTest
+@QuarkusTestResource(TestLifecycleManager.class)
+public class PoliciesHistoryCleanerTest {
+
+    @Inject
+    Session session;
+
+    @Inject
+    PoliciesHistoryCleaner policiesHistoryCleaner;
+
+    @BeforeEach
+    @Transactional
+    public void beforeEach() {
+        session.createQuery("DELETE FROM PoliciesHistoryEntry")
+                .executeUpdate();
+    }
+
+    @Test
+    @TestTransaction
+    public void testWithDefaultConfiguration() {
+        createPoliciesHistoryEntry(Instant.now().minus(Duration.ofHours(1L)));
+        createPoliciesHistoryEntry(Instant.now().minus(Duration.ofDays(28L)));
+        assertCount(2L);
+        policiesHistoryCleaner.clean();
+        assertCount(1L);
+    }
+
+    @Test
+    @TestTransaction
+    public void testWithCustomConfiguration() {
+        System.setProperty(POLICIES_HISTORY_CLEANER_DELETE_AFTER_CONF_KEY, "30m");
+        createPoliciesHistoryEntry(Instant.now().minus(Duration.ofHours(1L)));
+        createPoliciesHistoryEntry(Instant.now().minus(Duration.ofDays(28L)));
+        assertCount(2L);
+        policiesHistoryCleaner.clean();
+        assertCount(0L);
+        System.clearProperty(POLICIES_HISTORY_CLEANER_DELETE_AFTER_CONF_KEY);
+    }
+
+    private void createPoliciesHistoryEntry(Instant ctime) {
+        PoliciesHistoryEntry historyEntry = new PoliciesHistoryEntry();
+        historyEntry.setId(UUID.randomUUID());
+        historyEntry.setTenantId("tenant-id");
+        historyEntry.setPolicyId("policy-id");
+        historyEntry.setCtime(ctime.toEpochMilli());
+        session.persist(historyEntry);
+    }
+
+    private void assertCount(long expectedCount) {
+        long actualCount = session.createQuery("SELECT COUNT(*) FROM PoliciesHistoryEntry", Long.class)
+                .getSingleResult();
+        assertEquals(expectedCount, actualCount);
+    }
+}


### PR DESCRIPTION
The default history retention delay is 14 days. It can be changed with the `policies-history.cleaner.delete-after` conf property which accepts a `Duration` value compatible with the ISO-8601 duration format `PnDTnHnMn.nS`.

The scheduled job execution time doesn't really matter so I scheduled it with the `policies-history.cleaner.period` property which also accepts a `Duration` value. The default value is `P1D` which means once a day.