### PR TITLE
POL-559 Bump Quarkus to 2.1.3.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <java.release>11</java.release>
     <java.source>11</java.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>1.13.7.Final</quarkus.version>
+    <quarkus.version>2.1.3.Final</quarkus.version>
     <surefire-plugin.version>2.22.2</surefire-plugin.version>
     <jacoco.version>0.8.7</jacoco.version>
 

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -1028,7 +1028,7 @@ public class PolicyCrudService {
     Response response = null;
     String alerts;
     Span span = tracer.buildSpan("fetchLastTriggeredFromEngine").asChildOf(tracer.activeSpan()).start();
-    Scope scope = tracer.scopeManager().activate(span,false);
+    Scope scope = tracer.scopeManager().activate(span);
     try {
       response = engine.findLastTriggered(policyId.toString(),
               true, // thin
@@ -1064,8 +1064,12 @@ public class PolicyCrudService {
     // The engine may not have returned data to us
     if (totalCount > 0) {
       span = tracer.buildSpan("extractTriggerHistory").asChildOf(tracer.activeSpan()).start();
-      try (Scope ignored = tracer.scopeManager().activate(span,true)) {
+      try (Scope ignored = tracer.scopeManager().activate(span)) {
         parseHistoryFromEngine(alerts, items);
+      } finally {
+        if (span != null) {
+          span.finish();
+        }
       }
     }
     Page<HistoryItem> itemsPage = new Page<>(items,pager,totalCount);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,7 +56,6 @@ notifications/mp-rest/connectTimeout=2000
 notifications/mp-rest/readTimeout=2000
 
 # Quarkus since 1.11 redirects non-apps to /q/. We need to prevent this
-quarkus.http.redirect-to-non-application-root-path=false
 quarkus.http.non-application-root-path=/
 
 # OpenAPI path

--- a/src/test/java/com/redhat/cloud/policies/app/NonApplicationRootPathTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/NonApplicationRootPathTest.java
@@ -1,0 +1,47 @@
+package com.redhat.cloud.policies.app;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.config;
+import static io.restassured.RestAssured.given;
+import static io.restassured.config.RedirectConfig.redirectConfig;
+import static io.restassured.http.ContentType.JSON;
+import static io.restassured.http.ContentType.TEXT;
+
+@QuarkusTest
+public class NonApplicationRootPathTest {
+
+    @BeforeAll
+    static void beforeAll() {
+        config = config().redirect(redirectConfig().followRedirects(false));
+    }
+
+    @Test
+    void testHealth() {
+        given()
+                .when().get("/health")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
+    }
+
+    @Test
+    void testMetrics() {
+        given()
+                .when().get("/metrics")
+                .then()
+                .statusCode(200)
+                .contentType(TEXT);
+    }
+
+    @Test
+    void testOpenApi() {
+        given()
+                .when().get("/api/policies/v1.0/openapi.json")
+                .then()
+                .statusCode(200)
+                .contentType(JSON);
+    }
+}


### PR DESCRIPTION
The Quarkus path change is documented [here](https://github.com/quarkusio/quarkus/wiki/Migration-Guide-2.0#legacy-redirect-for-non-application-endpoints-such-as-health). The doc is not accurate though: `/health` and `/metrics` work without declaring an absolute path.

Opentracing changes are documented [here](https://github.com/opentracing/opentracing-java/blob/master/CHANGELOG.md#v0330-2019-05-06).