### PR TITLE
POL-559 Disable Jaeger

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -65,6 +65,7 @@ mp.openapi.filter=com.redhat.cloud.policies.app.openapi.OASModifier
 # Should the rbac filter emit a warning when RBAC calls take > 500ms? Default is true
 warn.rbac.slow=true
 
+quarkus.jaeger.enabled=false
 quarkus.jaeger.service-name=policies-api 
 quarkus.jaeger.sampler-type=const
 quarkus.jaeger.sampler-param=1


### PR DESCRIPTION
Opentracing (Jaeger) started logging a lot of WARN entries on OpenShift (CI and stage) after the Quarkus 2 bump:

```
2021-08-24 13:14:17,827 WARN  [io.jae.int.rep.RemoteReporter] (jaeger.RemoteReporter-QueueProcessor) FlushCommand execution failed! Repeated errors of this command will not be logged.: io.jaegertracing.internal.exceptions.SenderException: Failed to flush spans.
    at io.jaegertracing.thrift.internal.senders.ThriftSender.flush(ThriftSender.java:115)
    at io.jaegertracing.internal.reporters.RemoteReporter$FlushCommand.execute(RemoteReporter.java:160)
    at io.jaegertracing.internal.reporters.RemoteReporter$QueueProcessor.run(RemoteReporter.java:182)
    at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: io.jaegertracing.internal.exceptions.SenderException: Could not send 7 spans
    at io.jaegertracing.thrift.internal.senders.UdpSender.send(UdpSender.java:85)
    at io.jaegertracing.thrift.internal.senders.ThriftSender.flush(ThriftSender.java:113)
    ... 3 more
Caused by: org.apache.thrift.transport.TTransportException: Cannot flush closed transport
    at io.jaegertracing.thrift.internal.reporters.protocols.ThriftUdpTransport.flush(ThriftUdpTransport.java:148)
    at org.apache.thrift.TServiceClient.sendBase(TServiceClient.java:73)
    at org.apache.thrift.TServiceClient.sendBaseOneway(TServiceClient.java:66)
    at io.jaegertracing.agent.thrift.Agent$Client.send_emitBatch(Agent.java:70)
    at io.jaegertracing.agent.thrift.Agent$Client.emitBatch(Agent.java:63)
    at io.jaegertracing.thrift.internal.senders.UdpSender.send(UdpSender.java:83)
    ... 4 more
Caused by: java.net.PortUnreachableException: ICMP Port Unreachable
    at java.base/java.net.PlainDatagramSocketImpl.send(Native Method)
    at java.base/java.net.DatagramSocket.send(DatagramSocket.java:695)
    at io.jaegertracing.thrift.internal.reporters.protocols.ThriftUdpTransport.flush(ThriftUdpTransport.java:146)
    ... 9 more
```

Upstream issue: https://github.com/quarkusio/quarkus/issues/19653