### PR TITLE
Change datasource dialect to PostgreSQL10Dialect

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:tracing:postgresql://localhost:5432/postgres
 # use the 'TracingDriver' instead of the one for your database
 quarkus.datasource.jdbc.driver=io.opentracing.contrib.jdbc.TracingDriver
 # configure Hibernate dialect
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQLDialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQL10Dialect
 quarkus.datasource.username = postgres
 quarkus.datasource.password = postgres
 # The next are to check if connections are valid.


### PR DESCRIPTION
~Quarkus uses `PostgreSQL10Dialect` (the latest available) by default if no dialect is specified in `application.properties`.~

I'm not entirely sure the Quarkus magic works well with `io.opentracing.contrib.jdbc.TracingDriver` so let's use an explicit dialect for now.