### PR TITLE
Downgrade Postgres dialect to PostgreSQL82Dialect

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,7 @@ quarkus.datasource.jdbc.url=jdbc:tracing:postgresql://localhost:5432/postgres
 # use the 'TracingDriver' instead of the one for your database
 quarkus.datasource.jdbc.driver=io.opentracing.contrib.jdbc.TracingDriver
 # configure Hibernate dialect
-quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQL10Dialect
+quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQL82Dialect
 quarkus.datasource.username = postgres
 quarkus.datasource.password = postgres
 # The next are to check if connections are valid.


### PR DESCRIPTION
`PostgreSQL10Dialect` is suspected to cause a memory leak. Let's see how it goes with this one.