### PR TITLE
Set additional heap dump flags

### DIFF
--- a/src/main/docker/Dockerfile-build.jvm
+++ b/src/main/docker/Dockerfile-build.jvm
@@ -32,7 +32,7 @@ RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
     && echo "securerandom.source=file:/dev/urandom" >> /etc/alternatives/jre/lib/security/java.security
 
 # Configure the JAVA_OPTIONS, you can add -XshowSettings:vm to also display the heap size.
-ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager"
+ENV JAVA_OPTIONS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -XX:-ExitOnOutOfMemoryError -XX:+HeapDumpOnOutOfMemoryError"
 
 COPY --from=build --chown=1001 /home/jboss/target/quarkus-app/ /deployments/
 


### PR DESCRIPTION
disable exiting and enable heap dump.
This is temporary and needs to be reverted.