### PR TITLE
Revert "Log policies-engine URL at startup (#287)"

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -120,12 +120,6 @@ public class PolicyCrudService {
     @ConfigProperty(name = POLICIES_HISTORY_ENABLED_CONF_KEY, defaultValue = "false")
     boolean policiesHistoryEnabled;
 
-    @ConfigProperty(name = "clowder.endpoints.policies-engine", defaultValue = "NO SET")
-    String engineUrlFromClowder;
-
-    @ConfigProperty(name = "engine/mp-rest/url", defaultValue = "NO SET")
-    String engineMpRestUrl;
-
     @Inject
     @RestClient
     PolicyEngine engine;
@@ -169,9 +163,6 @@ public class PolicyCrudService {
         } else {
             log.info("Policies history is disabled. The history data will be retrieved from Infinispan.");
         }
-        // TODO This is needed to fix a Clowder issue. Remove it ASAP.
-        log.info("Engine URL from Clowder: " + engineUrlFromClowder);
-        log.info("Engine MP URL: " + engineMpRestUrl);
     }
 
     @Operation(summary = "Return all policies for a given account")


### PR DESCRIPTION
This reverts commit 7f4516879032d006424c90e38f2c40c9b2069b21.

When a Clowder file is provided, the app fails to start and show this error message:
```
Failed to load config value of type class java.lang.String for: clowder.endpoints.policies-engine
```