### PR TITLE
Change QUARKUS_HTTP_PORT to 8000 for Clowder

### DIFF
--- a/deploy/clowdapp.yaml
+++ b/deploy/clowdapp.yaml
@@ -69,6 +69,8 @@ objects:
           value: ${CLOWDER_ENABLED}
         - name: POLICIES_HISTORY_ENABLED
           value: ${POLICIES_HISTORY_ENABLED}
+        - name: QUARKUS_HTTP_PORT
+          value: "8000"
         resources:
           limits:
             cpu: ${CPU_LIMIT}


### PR DESCRIPTION
This is required for the stage deployment with Clowder.