### PR TITLE
POL-570 Load last trigger time from Postgres

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/model/history/PoliciesHistoryRepository.java
+++ b/src/main/java/com/redhat/cloud/policies/app/model/history/PoliciesHistoryRepository.java
@@ -82,6 +82,14 @@ public class PoliciesHistoryRepository {
         return query.getResultList();
     }
 
+    public Long getLastTriggerTime(String tenantId, UUID policyId) {
+        String hql = "SELECT MAX(ctime) FROM PoliciesHistoryEntry WHERE tenantId = :tenantId AND policyId = :policyId";
+        return session.createQuery(hql, Long.class)
+                .setParameter("tenantId", tenantId)
+                .setParameter("policyId", policyId.toString())
+                .getSingleResult();
+    }
+
     private static String addFiltersConditions(String hql, List<Filter.FilterItem> filterItems) {
         // The filters from the pager are added to the HQL query.
         for (Filter.FilterItem filterItem : filterItems) {

--- a/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RestApiTest.java
@@ -24,9 +24,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
+import com.redhat.cloud.policies.app.model.history.PoliciesHistoryRepository;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.mockito.InjectMock;
 import io.restassured.http.ContentType;
 import io.restassured.http.Header;
 import io.restassured.http.Headers;
@@ -36,6 +39,7 @@ import io.restassured.response.ExtractableResponse;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -58,6 +62,9 @@ class RestApiTest extends AbstractITest {
 
     @Inject
     TestUUIDHelperBean uuidHelper;
+
+    @InjectMock
+    PoliciesHistoryRepository policiesHistoryRepository;
 
     @AfterEach
     void cleanUUID() {
@@ -578,6 +585,9 @@ class RestApiTest extends AbstractITest {
 
     @Test
     void testGetOnePolicy() {
+        when(policiesHistoryRepository.getLastTriggerTime("1234", UUID.fromString("bd0ee2ec-eec0-44a6-8bb1-29c4179fc21c")))
+                .thenReturn(new GregorianCalendar(2020, 4, 10, 10, 0, 0).getTimeInMillis());
+
         JsonPath jsonPath =
                 given()
                         .header(authHeader)


### PR DESCRIPTION
I suspect the memory issue we had for a while was not caused by a memory leak but rather by huge triggers lifecycle data returned by the engine when we need to retrieve the last trigger time.

After this PR, ui-backend will no longer retrieve any "last trigger time" from the engine.

Whether my hypothesis is right or not, this will be an improvement anyway.