### PR TITLE
POL-621 Make the notifications-backend Clowder dependency optional

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -13,9 +13,10 @@ objects:
   spec:
     envName: ${ENV_NAME}
     dependencies:
-    - notifications-backend
     - policies-engine
     - rbac
+    optionalDependencies:
+    - notifications-backend
     database:
       name: policies-ui-backend
       version: 12


### PR DESCRIPTION
Policies-ui-backend needs this to be deployed on fedramp-stage.