### PR TITLE
Fix deprecated CronJob apiVersion

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -89,7 +89,7 @@ objects:
       cat /policies-db-cleaner/clean.sql | psql > /dev/null
     clean.sql: |
       CALL cleanPoliciesHistory();
-- apiVersion: batch/v1beta1
+- apiVersion: batch/v1
   kind: CronJob
   metadata:
     name: policies-db-cleaner-cronjob


### PR DESCRIPTION
Fixes
```
11:47:34 2022-01-25 10:47:34 [    INFO] [           pid-26005]  |stderr| W0125 10:47:34.765681   26005 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```

The first PR check run may fail because of an unrelated transitive dependency issue which is about to be fixed by the ingress team.