### PR TITLE
Decrease default CPU request/limit

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -145,10 +145,10 @@ parameters:
   value: "false"
 - name: CPU_LIMIT
   description: CPU limit
-  value: 500m
+  value: 200m
 - name: CPU_REQUEST
   description: CPU request
-  value: 500m
+  value: 100m
 - name: DB_CLEANER_SCHEDULE
   description: Execution time specified in cron format
   value: "*/10 * * * *"


### PR DESCRIPTION
Related to https://github.com/RedHatInsights/policies-engine/pull/394.

Metrics show that the current CPU request and limit are way above the actual CPU used by the containers on prod.