### PR TITLE
Use the new Quarkus Log API

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/EnvironmentInfo.java
+++ b/src/main/java/com/redhat/cloud/policies/app/EnvironmentInfo.java
@@ -1,8 +1,8 @@
 package com.redhat.cloud.policies.app;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.Startup;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 import javax.annotation.PostConstruct;
 import java.util.Optional;
@@ -10,17 +10,15 @@ import java.util.Optional;
 @Startup
 public class EnvironmentInfo {
 
-    private static final Logger LOG = Logger.getLogger(EnvironmentInfo.class);
-
     @ConfigProperty(name = "env.name")
     Optional<String> environmentName;
 
     @PostConstruct
     public void init() {
         if (environmentName.isPresent()) {
-            LOG.infof("Environment: %s", environmentName.get());
+            Log.infof("Environment: %s", environmentName.get());
         } else {
-            LOG.infof("Environment is not set");
+            Log.infof("Environment is not set");
         }
     }
 

--- a/src/main/java/com/redhat/cloud/policies/app/JaxRsApplication.java
+++ b/src/main/java/com/redhat/cloud/policies/app/JaxRsApplication.java
@@ -16,6 +16,7 @@
  */
 package com.redhat.cloud.policies.app;
 
+import io.quarkus.logging.Log;
 import io.quarkus.runtime.StartupEvent;
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -29,15 +30,12 @@ import javax.ws.rs.core.Application;
 
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 /**
  * Set the base path for the application
  */
 @ApplicationPath("/")
 public class JaxRsApplication extends Application {
-
-    Logger log = Logger.getLogger("Policies UI-Backend");
 
     public static final String FILTER_REGEX = ".*(/health(/\\w+)?|/metrics|/api/policies/v1.0/status) HTTP/[0-9].[0-9]\" 200.*\\n?";
     private static final Pattern pattern = Pattern.compile(FILTER_REGEX);
@@ -49,7 +47,7 @@ public class JaxRsApplication extends Application {
     void init(@Observes StartupEvent event) {
         initAccessLogFilter();
 
-        log.info(readGitProperties());
+        Log.info(readGitProperties());
 
         logExternalServiceUrl("quarkus.rest-client.engine.url");
         logExternalServiceUrl("quarkus.rest-client.notifications.url");
@@ -74,7 +72,7 @@ public class JaxRsApplication extends Application {
         try {
             return readFromInputStream(inputStream);
         } catch (IOException e) {
-            log.error("Could not read git.properties.", e);
+            Log.error("Could not read git.properties.", e);
             return "Version information could not be retrieved";
         }
     }
@@ -94,6 +92,6 @@ public class JaxRsApplication extends Application {
     }
 
     private void logExternalServiceUrl(String configKey) {
-        log.infof(configKey + "=%s", ConfigProvider.getConfig().getValue(configKey, String.class));
+        Log.infof(configKey + "=%s", ConfigProvider.getConfig().getValue(configKey, String.class));
     }
 }

--- a/src/main/java/com/redhat/cloud/policies/app/RouteRedirector.java
+++ b/src/main/java/com/redhat/cloud/policies/app/RouteRedirector.java
@@ -16,11 +16,9 @@
  */
 package com.redhat.cloud.policies.app;
 
+import io.quarkus.logging.Log;
 import io.quarkus.vertx.web.RouteFilter;
 import io.vertx.ext.web.RoutingContext;
-
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Redirect routes with only the major version
@@ -31,8 +29,6 @@ public class RouteRedirector {
 
     private static final String API_POLICIES_V_1 = "/api/policies/v1/";
     private static final String API_POLICIES_V_1_0 = "/api/policies/v1.0/";
-
-    Logger log = Logger.getLogger(this.getClass().getSimpleName());
 
     /**
      * If the requested route is the one with major version only,
@@ -45,15 +41,15 @@ public class RouteRedirector {
     @RouteFilter(400)
     void myRedirector(RoutingContext rc) {
         String uri = rc.request().uri();
-        if (log.isLoggable(Level.FINER)) {
+        if (Log.isTraceEnabled()) {
             uri = uri.replaceAll("[\n|\r|\t]", "_");
-            log.finer("Incoming uri: " + uri);
+            Log.trace("Incoming uri: " + uri);
         }
         if (uri.startsWith(API_POLICIES_V_1)) {
             String remain = uri.substring(API_POLICIES_V_1.length());
-            if (log.isLoggable(Level.FINER)) {
+            if (Log.isTraceEnabled()) {
                 remain = remain.replaceAll("[\n|\r|\t]", "_");
-                log.finer("Rerouting to :" + API_POLICIES_V_1_0 + remain);
+                Log.trace("Rerouting to :" + API_POLICIES_V_1_0 + remain);
             }
 
             rc.reroute(API_POLICIES_V_1_0 + remain);

--- a/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/IncomingRequestFilter.java
@@ -16,6 +16,7 @@
  */
 package com.redhat.cloud.policies.app.auth;
 
+import io.quarkus.logging.Log;
 import io.quarkus.vertx.http.runtime.CurrentVertxRequest;
 import io.vertx.ext.web.RoutingContext;
 
@@ -29,8 +30,6 @@ import javax.ws.rs.core.SecurityContext;
 import javax.ws.rs.ext.Provider;
 import java.io.IOException;
 import java.util.Optional;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Request filter. This runs on all incoming requests before method matching
@@ -60,9 +59,6 @@ public class IncomingRequestFilter implements ContainerRequestFilter {
 
     public static final String X_RH_ACCOUNT = "x-rh-account";
     public static final String X_RH_USER = "x-rh-user";
-
-    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
-    private final boolean logFine = log.isLoggable(Level.FINE);
 
     @Inject
     RhIdPrincipalProducer producer;
@@ -134,9 +130,7 @@ public class IncomingRequestFilter implements ContainerRequestFilter {
     }
 
     private void logIfNeeded(String logMessage) {
-        if (logFine) {
-            log.fine(logMessage);
-        }
+        Log.debug(logMessage);
     }
 
     // Helper to get the vert.x routing context

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -31,14 +31,12 @@ import javax.ws.rs.container.ContainerRequestFilter;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.ext.Provider;
 
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
-import org.jboss.logging.Logger;
 
 @Provider
 @Priority(Priorities.HEADER_DECORATOR + 1)
 public class RbacFilter implements ContainerRequestFilter {
-
-    private static final Logger LOGGER = Logger.getLogger(RbacFilter.class);
 
     @Inject
     Tracer tracer;
@@ -79,13 +77,13 @@ public class RbacFilter implements ContainerRequestFilter {
         try (Scope ignored = tracer.scopeManager().activate(span)) {
             result = rbacClient.getRbacInfo(user.getRawRhIdHeader());
         } catch (Throwable e) {
-            LOGGER.warn("RBAC call failed", e);
+            Log.warn("RBAC call failed", e);
             requestContext.abortWith(Response.status(Response.Status.FORBIDDEN).build());
             return;
         } finally {
             long t2 = System.currentTimeMillis();
             if (warnSlowRbac.get() && (t2 - t1) > warnSlowRbacTolerance.toMillis()) {
-                LOGGER.warnf("Call to RBAC took %d ms", t2 - t1);
+                Log.warnf("Call to RBAC took %d ms", t2 - t1);
             }
             span.finish();
         }

--- a/src/main/java/com/redhat/cloud/policies/app/health/ProcSelfStatusExporter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/health/ProcSelfStatusExporter.java
@@ -16,6 +16,7 @@
  */
 package com.redhat.cloud.policies.app.health;
 
+import io.quarkus.logging.Log;
 import io.quarkus.scheduler.Scheduled;
 import org.eclipse.microprofile.metrics.MetricUnits;
 import org.eclipse.microprofile.metrics.annotation.Gauge;
@@ -23,7 +24,6 @@ import org.eclipse.microprofile.metrics.annotation.Gauge;
 import javax.enterprise.context.ApplicationScoped;
 import java.io.File;
 import java.util.Scanner;
-import java.util.logging.Logger;
 
 
 /**
@@ -40,8 +40,6 @@ import java.util.logging.Logger;
  */
 @ApplicationScoped
 public class ProcSelfStatusExporter {
-
-    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
 
     private static final String PATHNAME = "/proc/self/status";
 
@@ -63,7 +61,7 @@ public class ProcSelfStatusExporter {
         File status = new File(PATHNAME);
         if (!status.exists() || !status.canRead()) {
             if (!hasWarned) {
-                log.warning("Can't read " + PATHNAME);
+                Log.warn("Can't read " + PATHNAME);
                 hasWarned = true;
             }
             return;
@@ -107,7 +105,7 @@ public class ProcSelfStatusExporter {
                 }
             }
         } catch (Exception e) {
-            log.warning("Reading failed: " + e.getMessage());
+            Log.warn("Reading failed: " + e.getMessage());
         }
     }
 

--- a/src/main/java/com/redhat/cloud/policies/app/health/StatusEndpoint.java
+++ b/src/main/java/com/redhat/cloud/policies/app/health/StatusEndpoint.java
@@ -17,6 +17,7 @@
 package com.redhat.cloud.policies.app.health;
 
 import com.redhat.cloud.policies.app.StuffHolder;
+import io.quarkus.logging.Log;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.GET;
@@ -24,7 +25,6 @@ import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.Response;
 import java.util.Map;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 /**
@@ -35,15 +35,13 @@ import java.util.stream.Collectors;
 @ApplicationScoped
 public class StatusEndpoint {
 
-    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
-
     @GET
     @Produces("application/json")
     public Response getStatus() {
         Map<String, String> issues = StuffHolder.getInstance().getStatusInfo();
 
         if (!issues.isEmpty()) {
-            log.severe("Status reports: " + makeReadable(issues));
+            Log.error("Status reports: " + makeReadable(issues));
             return Response.serverError().entity(issues).build();
         }
         return Response.ok().build();

--- a/src/main/java/com/redhat/cloud/policies/app/model/history/PoliciesHistoryRepository.java
+++ b/src/main/java/com/redhat/cloud/policies/app/model/history/PoliciesHistoryRepository.java
@@ -2,9 +2,9 @@ package com.redhat.cloud.policies.app.model.history;
 
 import com.redhat.cloud.policies.app.model.filter.Filter;
 import com.redhat.cloud.policies.app.model.pager.Pager;
+import io.quarkus.logging.Log;
 import io.quarkus.panache.common.Sort;
 import org.hibernate.Session;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.ApplicationScoped;
 import javax.inject.Inject;
@@ -20,8 +20,6 @@ import static com.redhat.cloud.policies.app.model.filter.Filter.Operator.LIKE;
 @ApplicationScoped
 public class PoliciesHistoryRepository {
 
-    private static final Logger LOGGER = Logger.getLogger(PoliciesHistoryRepository.class);
-
     @Inject
     Session session;
 
@@ -31,7 +29,7 @@ public class PoliciesHistoryRepository {
 
         hql = addFiltersConditions(hql, pager.getFilter().getItems());
 
-        LOGGER.tracef("HQL query ready to be executed: %s", hql);
+        Log.tracef("HQL query ready to be executed: %s", hql);
 
         TypedQuery<Long> query = session.createQuery(hql, Long.class)
                 .setParameter("tenantId", tenantId)
@@ -64,7 +62,7 @@ public class PoliciesHistoryRepository {
             hql += " ORDER BY ctime DESC, hostName ASC";
         }
 
-        LOGGER.tracef("HQL query ready to be executed: %s", hql);
+        Log.tracef("HQL query ready to be executed: %s", hql);
 
         TypedQuery<PoliciesHistoryEntry> query = session.createQuery(hql, PoliciesHistoryEntry.class)
                 .setParameter("tenantId", tenantId)

--- a/src/main/java/com/redhat/cloud/policies/app/rest/AdminService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/AdminService.java
@@ -42,15 +42,12 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
-import java.util.logging.Logger;
 
 @Path("/admin")
 @Produces("application/json")
 @Consumes("application/json")
 @RequestScoped
 public class AdminService {
-
-    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
 
     @Inject
     EntityManager entityManager;

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -28,6 +28,7 @@ import com.redhat.cloud.policies.app.model.pager.Page;
 import com.redhat.cloud.policies.app.model.pager.Pager;
 import com.redhat.cloud.policies.app.rest.utils.PagingUtils;
 import io.opentracing.Tracer;
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
@@ -42,7 +43,6 @@ import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
 import org.eclipse.microprofile.openapi.annotations.responses.APIResponses;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 import org.hibernate.exception.ConstraintViolationException;
-import org.jboss.logging.Logger;
 
 import javax.enterprise.context.RequestScoped;
 import javax.inject.Inject;
@@ -82,8 +82,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
-import static javax.ws.rs.core.Response.Status.CREATED;
-
 @Path("/api/policies/v1.0/policies")
 @Produces("application/json")
 @Consumes("application/json")
@@ -97,8 +95,6 @@ public class PolicyCrudService {
 
     public static final String ERROR_STRING = "error";
     public static final String CTIME_STRING = "ctime";
-
-    private final Logger log = Logger.getLogger(this.getClass());
 
     @Inject
     @RestClient
@@ -394,7 +390,7 @@ public class PolicyCrudService {
         if (t instanceof PersistenceException && t.getCause() instanceof ConstraintViolationException) {
             return Response.status(409, t.getMessage()).entity(new Msg("Constraint violation")).build();
         } else {
-            log.warn("Getting response failed", t);
+            Log.warn("Getting response failed", t);
             return Response.status(500, t.getMessage()).build();
         }
     }
@@ -808,7 +804,7 @@ public class PolicyCrudService {
             } catch (Exception e) {
                 tracer.activeSpan().setTag(ERROR_STRING, true);
                 String msg = "Retrieval of history failed with: " + e.getMessage();
-                log.warn(msg);
+                Log.warn(msg);
                 builder = Response.serverError().entity(msg);
             }
         }

--- a/src/main/java/com/redhat/cloud/policies/app/rest/UserConfigService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/UserConfigService.java
@@ -32,11 +32,10 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.ServerErrorException;
 import javax.ws.rs.core.Response;
 
+import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.metrics.annotation.SimplyTimed;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
-
-import java.util.logging.Logger;
 
 @Path("/api/policies/v1.0/user-config")
 @Produces("application/json")
@@ -44,8 +43,6 @@ import java.util.logging.Logger;
 @SimplyTimed(absolute = true, name = "UserConfigSvc")
 @RequestScoped
 public class UserConfigService {
-
-    private final Logger log = Logger.getLogger(this.getClass().getSimpleName());
 
     @SuppressWarnings("CdiInjectionPointsInspection")
     @Inject
@@ -79,7 +76,7 @@ public class UserConfigService {
         try {
             return notifications.getUserPreferences(bundle, application, user.getRawRhIdHeader());
         } catch (Exception e) {
-            log.warning("Retrieving settings failed: " + e.getMessage());
+            Log.warn("Retrieving settings failed: " + e.getMessage());
             throw new ServerErrorException(Response.serverError().entity(new Msg(e.getMessage())).build());
         }
     }


### PR DESCRIPTION
Quarkus recently introduced a new `Log` API which delegates all its invocations to `org.jboss.logging.Logger`. Building the logger is no longer needed.