### PR TITLE
POL-650 Add index-only scans to the policies_history table

### DIFF
--- a/src/main/resources/db/migration/V20__POL-650_history_org_id_index.sql
+++ b/src/main/resources/db/migration/V20__POL-650_history_org_id_index.sql
@@ -1,0 +1,3 @@
+-- This will enable index-only scans when Postgres retrieves the policies history data.
+CREATE INDEX ix_policies_history_index_only_scan
+    ON policies_history (policy_id, org_id, tenant_id, ctime, host_id, host_name, id);


### PR DESCRIPTION
The policies history request is extremely slow from the frontend when the `orgId` is enabled because of a missing index.

This PR will fix that.