### PR TITLE
POL-650 Make the policies_history index with org_id smaller

### DIFF
--- a/src/main/resources/db/migration/V20__POL-650_history_org_id_index.sql
+++ b/src/main/resources/db/migration/V20__POL-650_history_org_id_index.sql
@@ -1,3 +1,2 @@
--- This will enable index-only scans when Postgres retrieves the policies history data.
-CREATE INDEX ix_policies_history_index_only_scan
-    ON policies_history (policy_id, org_id, tenant_id, ctime, host_id, host_name, id);
+CREATE INDEX ix_policies_history_policy_id_org_id
+    ON policies_history (policy_id, org_id);


### PR DESCRIPTION
The previous version of the migration script hasn't been executed yet on stage or prod. The migration failed on stage because it requires too much time and the pod gets killed by the health checks before the migration succeeds.

We will use index-only scans later, after the `tenant_id` has been removed from the DB. For now, a simpler index will be enough.