### PR TITLE
POL-650 Temporarily allow more probes failures

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -117,7 +117,7 @@ objects:
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 20
         livenessProbe:
           httpGet:
             path: /health/live
@@ -127,7 +127,7 @@ objects:
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 3
+          failureThreshold: 20
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}


### PR DESCRIPTION
The next prod deployment will need more startup time because of an index creation. This should help preventing the pod from being killed because of probes failures.