### PR TITLE
Revert "POL-650 Temporarily allow more probes failures (#471)"

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -117,7 +117,7 @@ objects:
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 20
+          failureThreshold: 3
         livenessProbe:
           httpGet:
             path: /health/live
@@ -127,7 +127,7 @@ objects:
           periodSeconds: 10
           timeoutSeconds: 1
           successThreshold: 1
-          failureThreshold: 20
+          failureThreshold: 3
         env:
         - name: ENV_NAME
           value: ${ENV_NAME}


### PR DESCRIPTION
Reverts #471.

Prod DB has been migrated. This is no longer needed.