### PR TITLE
Bump Quarkus to 2.11 and then log the org id in access log.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
   <properties>
     <enforcer-plugin.version>3.1.0</enforcer-plugin.version>
-    <maven-minimum-version>3.8.1</maven-minimum-version>
+    <maven-minimum-version>3.8.6</maven-minimum-version>
     <java-version>11</java-version>
 
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
@@ -18,7 +18,7 @@
     <java.release>${java-version}</java.release>
     <java.source>${java-version}</java.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>2.10.2.Final</quarkus.version>
+    <quarkus.version>2.11.0.Final</quarkus.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven-jar-plugin.version>3.2.2</maven-jar-plugin.version>
     <jacoco.version>0.8.8</jacoco.version>

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -83,7 +83,7 @@ public class RbacFilter implements ContainerRequestFilter {
         } finally {
             long t2 = System.currentTimeMillis();
             if (warnSlowRbac.get() && (t2 - t1) > warnSlowRbacTolerance.toMillis()) {
-                Log.warnf("Call to RBAC took %d ms", t2 - t1);
+                Log.warnf("Call to RBAC took %d ms for orgId %s", t2 - t1, user.getOrgId());
             }
             span.finish();
         }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -37,7 +37,7 @@ quarkus.log.sentry.dsn=FILL_ME
 # access logging
 quarkus.http.access-log.enabled=true
 quarkus.http.access-log.category=access_log
-quarkus.http.access-log.pattern=combined
+quarkus.http.access-log.pattern="%h %l %u %t \"%r\" %s %b orgId=%{d,x-rh-rbac-org-id}"
 
 # our engine backend for verification of policies
 quarkus.rest-client.engine.url=${clowder.endpoints.policies-engine-service:http://localhost:8084}


### PR DESCRIPTION
Also log orgId on slow rbac

This will then look like

`2022-07-20 17:33:26,462 INFO  [access_log] (executor-thread-0) "127.0.0.1 - hrupp 20/Jul/2022:17:33:26 -0400 "GET /api/policies/v1.0/policies HTTP/1.1" 403 - orgId=1234567"
`