### PR TITLE
Use org_id in rule_policies_history_last_triggered

### DIFF
--- a/src/main/resources/db/migration/V22__POL-650_policies_history_rule.sql
+++ b/src/main/resources/db/migration/V22__POL-650_policies_history_rule.sql
@@ -1,0 +1,6 @@
+DROP RULE rule_policies_history_last_triggered ON policies_history;
+
+CREATE RULE rule_policies_history_last_triggered AS ON INSERT TO policies_history
+DO UPDATE policy
+   SET last_triggered = GREATEST(last_triggered, NEW.ctime)
+   WHERE id = uuid(NEW.policy_id) and org_id = NEW.org_id;


### PR DESCRIPTION
Initial rule: https://github.com/RedHatInsights/policies-ui-backend/blob/28054b0e41f6e37d6d006b89d8f505bdb041dd35/src/main/resources/db/migration/V18__POL-453-expose-last-triggered-to-policies.sql#L3-L6