### PR TITLE
refactor(repository): use native SQL for history

### DIFF
--- a/src/test/java/com/redhat/cloud/policies/app/model/history/PoliciesHistoryRepositoryTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/model/history/PoliciesHistoryRepositoryTest.java
@@ -6,6 +6,8 @@ import com.redhat.cloud.policies.app.model.pager.Pager;
 import io.quarkus.test.common.QuarkusTestResource;
 import io.quarkus.test.junit.QuarkusTest;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.api.BeforeAll;
 
 import javax.inject.Inject;
 import java.util.List;
@@ -21,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @QuarkusTest
 @QuarkusTestResource(TestLifecycleManager.class)
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class PoliciesHistoryRepositoryTest {
 
     private static final String TENANT_ID_1 = "tenant-id-1";
@@ -40,23 +43,22 @@ class PoliciesHistoryRepositoryTest {
     @Inject
     PoliciesHistoryRepository repository;
 
+    private static List<PoliciesHistoryEntry> insertedEntries;
+
+    @BeforeAll
+    void setUp() {
+        insertedEntries = List.of(
+            helper.createPoliciesHistoryEntry(TENANT_ID_1, ORG_ID_1, POLICY_ID_1, HOST_ID_1, HOST_NAME_1, 1L),
+            helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_1, HOST_ID_1, HOST_NAME_1, 2L),
+            helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_1, HOST_NAME_1, 3L),
+            helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_1, HOST_NAME_2, 3L),
+            helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_2 + "-foo", HOST_NAME_2, 4L),
+            helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_2, "bar-" + HOST_NAME_2, 5L)
+        );
+    }
+
     @Test
-    void test() {
-
-        /*
-         * Some of the following history entries don't make sense from a functional perspective, but it doesn't matter.
-         * The only goal here is to test things from a technical perspective.
-         */
-        PoliciesHistoryEntry historyEntry1 = helper.createPoliciesHistoryEntry(TENANT_ID_1, ORG_ID_1, POLICY_ID_1, HOST_ID_1, HOST_NAME_1, 1L);
-        PoliciesHistoryEntry historyEntry2 = helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_1, HOST_ID_1, HOST_NAME_1, 2L);
-        PoliciesHistoryEntry historyEntry3 = helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_1, HOST_NAME_1, 3L);
-        PoliciesHistoryEntry historyEntry4 = helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_1, HOST_NAME_2, 3L);
-        PoliciesHistoryEntry historyEntry5 = helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_2 + "-foo", HOST_NAME_2, 4L);
-        PoliciesHistoryEntry historyEntry6 = helper.createPoliciesHistoryEntry(TENANT_ID_2, ORG_ID_2, POLICY_ID_2, HOST_ID_2, "bar-" + HOST_NAME_2, 5L);
-
-        /*
-         * Pager #1: empty settings.
-         */
+    void testPagerEmptySettings() {
         Pager pager = Pager.builder().build();
 
         assertEquals(0, repository.count("unknown-org-id", POLICY_ID_1, pager));
@@ -67,71 +69,73 @@ class PoliciesHistoryRepositoryTest {
 
         assertTrue(repository.find("unknown-org-id", POLICY_ID_1, pager).isEmpty());
         assertTrue(repository.find(ORG_ID_1, UUID.randomUUID(), pager).isEmpty());
-        assertEquals(List.of(historyEntry1), repository.find(ORG_ID_1, POLICY_ID_1, pager));
-        assertEquals(List.of(historyEntry2), repository.find(ORG_ID_2, POLICY_ID_1, pager));
-        assertEquals(List.of(historyEntry6, historyEntry5, historyEntry3, historyEntry4), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(0)), repository.find(ORG_ID_1, POLICY_ID_1, pager));
+        assertEquals(List.of(insertedEntries.get(1)), repository.find(ORG_ID_2, POLICY_ID_1, pager));
+        assertEquals(List.of(insertedEntries.get(5), insertedEntries.get(4), insertedEntries.get(2), insertedEntries.get(3)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
 
-        /*
-         * Pager #2: single EQUAL filter.
-         */
-        pager = Pager.builder().filter("name", EQUAL, "host-name").build();
+    @Test
+    void testPagerSingleEqualFilter() {
+        Pager pager = Pager.builder().filter("name", EQUAL, "host-name").build();
         assertEquals(0, repository.count(ORG_ID_2, POLICY_ID_2, pager));
         assertTrue(repository.find(ORG_ID_2, POLICY_ID_2, pager).isEmpty());
+    }
 
-        /*
-         * Pager #3: single LIKE filter.
-         */
-        pager = Pager.builder().filter("name", LIKE, "host-name-2").build();
+    @Test
+    void testPagerSingleNotEqualFilter() {
+        Pager pager = Pager.builder().filter("name", NOT_EQUAL, "red-hat").build();
+        assertEquals(4, repository.count(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(5), insertedEntries.get(4), insertedEntries.get(2), insertedEntries.get(3)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
+
+    @Test
+    void testPagerSingleLikeFilter() {
+        Pager pager = Pager.builder().filter("name", LIKE, "host-name-2").build();
         assertEquals(3, repository.count(ORG_ID_2, POLICY_ID_2, pager));
-        assertEquals(List.of(historyEntry6, historyEntry5, historyEntry4), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(5), insertedEntries.get(4), insertedEntries.get(3)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
 
-        /*
-         * Pager #4: single NOT_EQUAL filter.
-         */
-        pager = Pager.builder().filter("name", NOT_EQUAL, "red-hat").build();
-        assertEquals(4, repository.count(ORG_ID_2, POLICY_ID_2, pager));
-        assertEquals(List.of(historyEntry6, historyEntry5, historyEntry3, historyEntry4), repository.find(ORG_ID_2, POLICY_ID_2, pager));
-
-        /*
-         * Pager #5: combined EQUAL and LIKE filters.
-         */
-        pager = Pager.builder().filter("id", EQUAL, HOST_ID_2).filter("name", LIKE, "bar-").build();
+    @Test
+    void testPagerCombinedEqAndLikeFilters() {
+        Pager pager = Pager.builder().filter("id", EQUAL, HOST_ID_2).filter("name", LIKE, "bar-").build();
         assertEquals(1, repository.count(ORG_ID_2, POLICY_ID_2, pager));
-        assertEquals(List.of(historyEntry6), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(5)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
 
-        /*
-         * Pager #6: single sort.
-         */
-        pager = Pager.builder().addSort("ctime", Ascending).build();
+    @Test
+    void testPagerSingleSort() {
+        Pager pager = Pager.builder().addSort("ctime", Ascending).build();
         assertEquals(4, repository.count(ORG_ID_2, POLICY_ID_2, pager));
-        assertEquals(List.of(historyEntry3, historyEntry4, historyEntry5, historyEntry6), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(2), insertedEntries.get(3), insertedEntries.get(4), insertedEntries.get(5)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
 
-        /*
-         * Pager #7: combined sorts.
-         */
-        pager = Pager.builder().addSort("id", Descending).addSort("name", Ascending).build();
+    @Test
+    void testCombinedSorts() {
+        Pager pager = Pager.builder().addSort("id", Descending).addSort("name", Ascending).build();
         assertEquals(4, repository.count(ORG_ID_2, POLICY_ID_2, pager));
-        assertEquals(List.of(historyEntry5, historyEntry6, historyEntry3, historyEntry4), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(4), insertedEntries.get(5), insertedEntries.get(2), insertedEntries.get(3)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
 
-        /*
-         * Pager #8: limit.
-         */
-        pager = Pager.builder().itemsPerPage(2).build();
+    @Test
+    void testPagerLimit() {
+        Pager pager = Pager.builder().itemsPerPage(2).build();
         assertEquals(4, repository.count(ORG_ID_2, POLICY_ID_2, pager));
-        assertEquals(List.of(historyEntry6, historyEntry5), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(5), insertedEntries.get(4)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
 
-        /*
-         * Pager #9: limit and offset.
-         */
-        pager = Pager.builder().itemsPerPage(1).page(3).build();
+    @Test
+    void testPagerLimitAndOffset() {
+        Pager pager = Pager.builder().itemsPerPage(1).page(3).build();
         assertEquals(4, repository.count(ORG_ID_2, POLICY_ID_2, pager));
-        assertEquals(List.of(historyEntry4), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+        assertEquals(List.of(insertedEntries.get(3)), repository.find(ORG_ID_2, POLICY_ID_2, pager));
+    }
 
+    @Test
+    void testPager() {
         /*
-         * Pager #10: everything.
          * The query result is not asserted. This is only here to make sure the app doesn't go boom when everything is combined.
          */
-        pager = Pager.builder()
+        Pager pager = Pager.builder()
                 .itemsPerPage(2)
                 .page(3)
                 .filter("name", EQUAL, "foo")


### PR DESCRIPTION
Refactors `PoliciesHistoryRepository` to use native SQL to support Postgresql-specific queries (like JSON lookups).

RHINENG-1191