### PR TITLE
feat(auth): RBAC attribute filters support

### DIFF
--- a/src/main/java/com/redhat/cloud/policies/app/RbacServer.java
+++ b/src/main/java/com/redhat/cloud/policies/app/RbacServer.java
@@ -16,7 +16,6 @@
  */
 package com.redhat.cloud.policies.app;
 
-import com.redhat.cloud.policies.app.auth.RbacRaw;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.HeaderParam;
@@ -25,6 +24,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+
+import com.redhat.cloud.policies.app.auth.models.RbacRaw;
 
 @Path("/api/rbac/v1")
 @RegisterRestClient(configKey = "rbac")

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacClient.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacClient.java
@@ -1,6 +1,8 @@
 package com.redhat.cloud.policies.app.auth;
 
 import com.redhat.cloud.policies.app.RbacServer;
+import com.redhat.cloud.policies.app.auth.models.RbacRaw;
+
 import io.quarkus.cache.CacheResult;
 import org.eclipse.microprofile.rest.client.inject.RestClient;
 

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -34,6 +34,8 @@ import javax.ws.rs.ext.Provider;
 import io.quarkus.logging.Log;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 
+import com.redhat.cloud.policies.app.auth.models.RbacRaw;
+
 @Provider
 @Priority(Priorities.HEADER_DECORATOR + 1)
 public class RbacFilter implements ContainerRequestFilter {

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacRaw.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacRaw.java
@@ -21,6 +21,8 @@ import java.util.Map;
 
 public class RbacRaw {
 
+    public static final String ANY = "*";
+
     public Map<String, String> links;
     public Map<String, Integer> meta;
     public List<Map<String, Object>> data;
@@ -34,11 +36,11 @@ public class RbacRaw {
     }
 
     public boolean canReadAll() {
-        return canRead("*");
+        return canRead(ANY);
     }
 
     public boolean canWriteAll() {
-        return canWrite("*");
+        return canWrite(ANY);
     }
 
     public boolean canDo(String path, String permission) {
@@ -53,8 +55,8 @@ public class RbacRaw {
 
         for (Map<String, Object> permissionEntry : data) {
             String[] fields = getPermissionFields(permissionEntry);
-            if (fields[1].equals(path) || fields[1].equals("*")) {
-                if (fields[2].equals(what) || fields[2].equals("*")) {
+            if (fields[1].equals(path) || fields[1].equals(ANY)) {
+                if (fields[2].equals(what) || fields[2].equals(ANY)) {
                     return true;
                 }
             }

--- a/src/main/java/com/redhat/cloud/policies/app/auth/models/Access.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/models/Access.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app.auth.models;
+
+import java.util.List;
+
+public class Access {
+
+    public String permission;
+    public List<ResourceDefinition> resourceDefinitions;
+
+}

--- a/src/main/java/com/redhat/cloud/policies/app/auth/models/RbacRaw.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/models/RbacRaw.java
@@ -25,7 +25,7 @@ public class RbacRaw {
 
     public Map<String, String> links;
     public Map<String, Integer> meta;
-    public List<Map<String, Object>> data;
+    public List<Access> data;
 
     public boolean canRead(String path) {
         return findPermission(path, "read");
@@ -53,7 +53,7 @@ public class RbacRaw {
             return false;
         }
 
-        for (Map<String, Object> permissionEntry : data) {
+        for (Access permissionEntry : data) {
             String[] fields = getPermissionFields(permissionEntry);
             if (fields[1].equals(path) || fields[1].equals(ANY)) {
                 if (fields[2].equals(what) || fields[2].equals(ANY)) {
@@ -64,8 +64,7 @@ public class RbacRaw {
         return false;
     }
 
-    private String[] getPermissionFields(Map<String, Object> map) {
-        String perms = (String) map.get("permission");
-        return perms.split(":");
+    private String[] getPermissionFields(Access map) {
+        return map.permission.split(":");
     }
 }

--- a/src/main/java/com/redhat/cloud/policies/app/auth/models/RbacRaw.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/models/RbacRaw.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.redhat.cloud.policies.app.auth;
+package com.redhat.cloud.policies.app.auth.models;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/com/redhat/cloud/policies/app/auth/models/ResourceDefinition.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/models/ResourceDefinition.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app.auth.models;
+
+public class ResourceDefinition {
+    public ResourceDefinitionFilter attributeFilter;
+}

--- a/src/main/java/com/redhat/cloud/policies/app/auth/models/ResourceDefinitionFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/models/ResourceDefinitionFilter.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2023 Red Hat, Inc. and/or its affiliates
+ * and other contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.redhat.cloud.policies.app.auth.models;
+
+import java.util.List;
+
+public class ResourceDefinitionFilter {
+    public String key;
+    public String operation;
+    public Object value;
+}

--- a/src/main/java/com/redhat/cloud/policies/app/auth/models/ResourceDefinitionFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/models/ResourceDefinitionFilter.java
@@ -18,8 +18,12 @@ package com.redhat.cloud.policies.app.auth.models;
 
 import java.util.List;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+
 public class ResourceDefinitionFilter {
     public String key;
     public String operation;
-    public Object value;
+
+    @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
+    public List<String> value;
 }

--- a/src/test/java/com/redhat/cloud/policies/app/RbacParsingTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RbacParsingTest.java
@@ -17,6 +17,8 @@
 package com.redhat.cloud.policies.app;
 
 import java.io.File;
+import java.util.List;
+
 
 import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
@@ -28,6 +30,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @QuarkusTest
 class RbacParsingTest {
@@ -82,5 +85,23 @@ class RbacParsingTest {
         assertFalse(rbac.canWriteAll());
         assertTrue(rbac.canDo("*", "execute"));
         assertTrue(rbac.canDo("foobar", "execute"));
+    }
+
+    @Test
+    void testResourceDefinitionsParsing() throws Exception {
+        File file = new File("src/test/resources/rbac_example.json");
+        RbacRaw rbac = objectMapper.readValue(file, RbacRaw.class);
+        assertEquals(3, rbac.data.size());
+
+        assertNotNull(rbac.data.get(0).resourceDefinitions);
+        assertEquals(0, rbac.data.get(0).resourceDefinitions.size());
+
+        assertNotNull(rbac.data.get(1).resourceDefinitions);
+        assertEquals(1, rbac.data.get(1).resourceDefinitions.size());
+        assertEquals(List.of("123456"), rbac.data.get(1).resourceDefinitions.get(0).attributeFilter.value);
+
+        assertNotNull(rbac.data.get(2).resourceDefinitions);
+        assertEquals(1, rbac.data.get(2).resourceDefinitions.size());
+        assertEquals(List.of("654321"), rbac.data.get(2).resourceDefinitions.get(0).attributeFilter.value);
     }
 }

--- a/src/test/java/com/redhat/cloud/policies/app/RbacParsingTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RbacParsingTest.java
@@ -16,7 +16,6 @@
  */
 package com.redhat.cloud.policies.app;
 
-import com.redhat.cloud.policies.app.auth.RbacRaw;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -24,6 +23,8 @@ import javax.json.bind.Jsonb;
 import javax.json.bind.JsonbBuilder;
 
 import org.junit.jupiter.api.Test;
+
+import com.redhat.cloud.policies.app.auth.models.RbacRaw;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;

--- a/src/test/java/com/redhat/cloud/policies/app/RbacParsingTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/RbacParsingTest.java
@@ -17,27 +17,29 @@
 package com.redhat.cloud.policies.app;
 
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import javax.json.bind.Jsonb;
-import javax.json.bind.JsonbBuilder;
 
+import javax.inject.Inject;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.redhat.cloud.policies.app.auth.models.RbacRaw;
 
+import io.quarkus.test.junit.QuarkusTest;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@QuarkusTest
 class RbacParsingTest {
+
+    @Inject
+    ObjectMapper objectMapper;
 
     @Test
     void testParseExample() throws Exception {
         File file = new File("src/test/resources/rbac_example.json");
-        Jsonb jb = JsonbBuilder.create();
-        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
-        assertEquals(rbac.data.size(), 2);
+        RbacRaw rbac = objectMapper.readValue(file, RbacRaw.class);
+        assertEquals(3, rbac.data.size());
 
         assertTrue(rbac.canWrite("resname"));
         // We don't have explicit read permission for "resname" but we have bar:*:read.
@@ -50,8 +52,7 @@ class RbacParsingTest {
     @Test
     void testNoAccess() throws Exception {
         File file = new File("src/test/resources/rbac_example_no_access.json");
-        Jsonb jb = JsonbBuilder.create();
-        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+        RbacRaw rbac = objectMapper.readValue(file, RbacRaw.class);
 
         assertFalse(rbac.canReadAll());
         assertFalse(rbac.canWriteAll());
@@ -62,8 +63,7 @@ class RbacParsingTest {
     @Test
     void testFullAccess() throws Exception {
         File file = new File("src/test/resources/rbac_example_full_access.json");
-        Jsonb jb = JsonbBuilder.create();
-        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+        RbacRaw rbac = objectMapper.readValue(file, RbacRaw.class);
 
         assertTrue(rbac.canRead("*"));
         assertTrue(rbac.canRead("anything"));
@@ -74,10 +74,9 @@ class RbacParsingTest {
     }
 
     @Test
-    void testPartialAccess() throws FileNotFoundException {
+    void testPartialAccess() throws Exception {
         File file = new File("src/test/resources/rbac_example_partial_access.json");
-        Jsonb jb = JsonbBuilder.create();
-        RbacRaw rbac = jb.fromJson(new FileInputStream(file), RbacRaw.class);
+        RbacRaw rbac = objectMapper.readValue(file, RbacRaw.class);
 
         assertTrue(rbac.canReadAll());
         assertFalse(rbac.canWriteAll());

--- a/src/test/resources/rbac_example.json
+++ b/src/test/resources/rbac_example.json
@@ -26,6 +26,18 @@
           }
         }
       ]
+    },
+    {
+      "permission": "foo:*:read",
+      "resourceDefinitions": [
+        {
+          "attributeFilter": {
+            "key": "hulla.accounts",
+            "operation": "in",
+            "value": ["654321"]
+          }
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Adds parsing of `attributeFilter` from RBAC access responses.

Refactors tests to use Jackson, the same as the RestClient uses.

_Hint: review by commits_

RHINENG-1304