### PR TITLE
Update Security-Compliance Tag Naming Convention

### DIFF
--- a/.rhcicd/build_deploy.sh
+++ b/.rhcicd/build_deploy.sh
@@ -17,7 +17,7 @@ mkdir -p "$DOCKER_CONF"
 
 IMAGE="quay.io/cloudservices/policies-ui-backend"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
-SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)"
+SECURITY_COMPLIANCE_TAG="sc-$(date +%Y%m%d)-$(git rev-parse --short=7 HEAD)"
 
 docker --config="$DOCKER_CONF" login -u="$QUAY_USER" -p="$QUAY_TOKEN" quay.io
 docker --config="$DOCKER_CONF" login -u="$RH_REGISTRY_USER" -p="$RH_REGISTRY_TOKEN" registry.redhat.io


### PR DESCRIPTION
## Overview
This PR updates the `Security-Compliance Tag` Naming Convention within the `build_deploy.sh` to make it easier to identify the Git Commit the image is based on.

Example:
- OLD: `sc-20230920`
- NEW: `sc-20230920-f963f6f`