### PR TITLE
fix: Update production server

### DIFF
--- a/src/main/resources/META-INF/openapi.json
+++ b/src/main/resources/META-INF/openapi.json
@@ -7,7 +7,7 @@
   },
   "servers": [
     {
-      "url": "https://cloud.redhat.com",
+      "url": "https://console.redhat.com",
       "description": "Production Server",
       "variables": {
         "basePath": {


### PR DESCRIPTION
Updates OpenAPI's production server to point to console.redhat.com instead of the old cloud.redhat.com
