### PR TITLE
chore: update quarkus 2.16.12

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <java.release>${java-version}</java.release>
     <java.source>${java-version}</java.source>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <quarkus.version>2.13.3.Final</quarkus.version>
+    <quarkus.version>2.16.12.Final</quarkus.version>
     <surefire-plugin.version>3.0.0-M7</surefire-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <jacoco.version>0.8.8</jacoco.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,8 +25,6 @@
 
     <version.testcontainers>1.17.6</version.testcontainers>
     <openapi-parser.version>4.0.4</openapi-parser.version>
-    <!-- temporary version update before switching to higher quarkus platform version -->
-    <netty-codec-http2.version>4.1.100.Final</netty-codec-http2.version>
     <mockserver-netty-no-dependencies.version>5.14.0</mockserver-netty-no-dependencies.version>
     <clowder-quarkus-config-source.version>1.3.2</clowder-quarkus-config-source.version>
   </properties>
@@ -128,12 +126,6 @@
       <groupId>io.quarkiverse.loggingsentry</groupId>
       <artifactId>quarkus-logging-sentry</artifactId>
       <version>1.2.1</version>
-    </dependency>
-
-    <dependency>
-        <groupId>io.netty</groupId>
-        <artifactId>netty-codec-http2</artifactId>
-        <version>${netty-codec-http2.version}</version>
     </dependency>
 
     <!-- ORM types support incl. JSON (for Hibernate <= 5) -->

--- a/src/test/java/com/redhat/cloud/policies/app/NonApplicationRootPathTest.java
+++ b/src/test/java/com/redhat/cloud/policies/app/NonApplicationRootPathTest.java
@@ -30,6 +30,7 @@ class NonApplicationRootPathTest {
     @Test
     void testMetrics() {
         given()
+                .header("Accept", "text/plain")
                 .when().get("/metrics")
                 .then()
                 .statusCode(200)


### PR DESCRIPTION
Upgrades to newest Quarkus 2: 2.16.12.

Refactors tests to support this upgrade, and cleans up direct dependency definition.

RHINENG-2697
