### PR TITLE
fix: drop unused and deprecated OpenTracing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,14 +67,6 @@
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-smallrye-opentracing</artifactId>
-    </dependency>
-    <dependency>
-       <groupId>io.opentracing.contrib</groupId>
-       <artifactId>opentracing-jdbc</artifactId>
-   </dependency>
-    <dependency>
-      <groupId>io.quarkus</groupId>
       <artifactId>quarkus-hibernate-validator</artifactId>
     </dependency>
     <dependency>

--- a/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
+++ b/src/main/java/com/redhat/cloud/policies/app/auth/RbacFilter.java
@@ -16,9 +16,6 @@
  */
 package com.redhat.cloud.policies.app.auth;
 
-import io.opentracing.Scope;
-import io.opentracing.Span;
-import io.opentracing.Tracer;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.List;
@@ -44,9 +41,6 @@ public class RbacFilter implements ContainerRequestFilter {
 
     public static final String APPLICATION = "policies";
     public static final String RESOURCE = "policies";
-
-    @Inject
-    Tracer tracer;
 
     @Inject
     RbacClient rbacClient;
@@ -99,8 +93,7 @@ public class RbacFilter implements ContainerRequestFilter {
     private RbacRaw getRbacResult() {
         RbacRaw result;
         long t1 = System.currentTimeMillis();
-        Span span = tracer.buildSpan("getRBac").start();
-        try (Scope ignored = tracer.scopeManager().activate(span)) {
+        try {
             result = rbacClient.getRbacInfo(user.getRawRhIdHeader());
         } catch (Throwable e) {
             Log.warn("RBAC call failed", e);
@@ -110,7 +103,6 @@ public class RbacFilter implements ContainerRequestFilter {
             if (warnSlowRbac.get() && (t2 - t1) > warnSlowRbacTolerance.get().toMillis()) {
                 Log.warnf("Call to RBAC took %d ms for orgId %s", t2 - t1, user.getOrgId());
             }
-            span.finish();
         }
 
         return result;

--- a/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
+++ b/src/main/java/com/redhat/cloud/policies/app/rest/PolicyCrudService.java
@@ -30,7 +30,6 @@ import com.redhat.cloud.policies.app.model.pager.Page;
 import com.redhat.cloud.policies.app.model.pager.Pager;
 import com.redhat.cloud.policies.app.rest.utils.PagingUtils;
 import io.micrometer.core.annotation.Timed;
-import io.opentracing.Tracer;
 import io.quarkus.logging.Log;
 import org.eclipse.microprofile.openapi.annotations.Operation;
 import org.eclipse.microprofile.openapi.annotations.enums.ParameterIn;
@@ -122,9 +121,6 @@ public class PolicyCrudService {
 
     @Inject
     Validator validator;
-
-    @Inject
-    Tracer tracer;
 
     @Inject
     PoliciesHistoryRepository policiesHistoryRepository;
@@ -808,10 +804,8 @@ public class PolicyCrudService {
                 Pager pager = PagingUtils.extractPager(uriInfo);
                 builder = buildHistoryResponse(policyId, pager);
             } catch (IllegalArgumentException iae) {
-                tracer.activeSpan().setTag(ERROR_STRING, true);
                 builder = Response.status(400, iae.getMessage());
             } catch (Exception e) {
-                tracer.activeSpan().setTag(ERROR_STRING, true);
                 String msg = "Retrieval of history failed with: " + e.getMessage();
                 Log.warn(msg);
                 builder = Response.serverError().entity(msg);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,5 @@
 quarkus.datasource.db-kind=postgresql
-quarkus.datasource.jdbc.url=jdbc:tracing:postgresql://localhost:5432/postgres
-# use the 'TracingDriver' instead of the one for your database
-quarkus.datasource.jdbc.driver=io.opentracing.contrib.jdbc.TracingDriver
+quarkus.datasource.jdbc.url=jdbc:postgresql://localhost:5432/postgres
 # configure Hibernate dialect
 quarkus.hibernate-orm.dialect=org.hibernate.dialect.PostgreSQL82Dialect
 quarkus.datasource.username = postgres
@@ -74,11 +72,6 @@ mp.openapi.filter=com.redhat.cloud.policies.app.openapi.OASModifier
 # Should the rbac filter emit a warning when RBAC calls take > 'warn.rbac.tolerance' ms? Default is true, with 1s
 warn.rbac.slow=true
 warn.rbac.tolerance=1S
-
-quarkus.jaeger.enabled=false
-quarkus.jaeger.service-name=policies-api 
-quarkus.jaeger.sampler-type=const
-quarkus.jaeger.sampler-param=1
 
 # Duration rbac entries are kept in cache
 quarkus.cache.caffeine.rbac-cache.expire-after-write=PT120s

--- a/src/test/java/com/redhat/cloud/policies/app/TestLifecycleManager.java
+++ b/src/test/java/com/redhat/cloud/policies/app/TestLifecycleManager.java
@@ -66,11 +66,7 @@ public class TestLifecycleManager implements QuarkusTestResourceLifecycleManager
     void setupPostgres(Map<String, String> props) {
         postgreSQLContainer = new PostgreSQLContainer<>("postgres");
         postgreSQLContainer.start();
-        // Now that postgres is started, we need to get its URL and tell Quarkus
-        // quarkus.datasource.driver=io.opentracing.contrib.jdbc.TracingDriver
-        // Driver needs a 'tracing' in the middle like jdbc:tracing:postgresql://localhost:5432/postgres
         String jdbcUrl = postgreSQLContainer.getJdbcUrl();
-        jdbcUrl = "jdbc:tracing:" + jdbcUrl.substring(jdbcUrl.indexOf(':') + 1);
         props.put("quarkus.datasource.jdbc.url", jdbcUrl);
         props.put("quarkus.datasource.username", "test");
         props.put("quarkus.datasource.password", "test");


### PR DESCRIPTION
OpenTracing has been deprecated in favor of OpenTelemetry in Quarkus.

Since, we are not actively using it, and have issues converting to OpenTelemetry (see #588), we're gonna drop it.

RHINENG-2951