### PR TITLE
fix: restartPolicy in OS template

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -109,7 +109,6 @@ objects:
               containers:
                 - name: policies-db-cleaner
                   image: quay.io/cloudservices/postgresql-rds:12-1
-                  restartPolicy: Never
                   resources:
                     requests:
                       cpu: 100m


### PR DESCRIPTION
Fixes
spec.jobTemplate.spec.template.spec.containers[0].restartPolicy: Forbidden: may not be set for non-init container

RHINENG-6805