### PR TITLE
refactor(dev): update postgresql-rds image tag

### DIFF
--- a/.rhcicd/clowdapp.yaml
+++ b/.rhcicd/clowdapp.yaml
@@ -108,7 +108,7 @@ objects:
                     name: policies-db-cleaner-config
               containers:
                 - name: policies-db-cleaner
-                  image: quay.io/cloudservices/postgresql-rds:12-1
+                  image: quay.io/cloudservices/postgresql-rds:12
                   resources:
                     requests:
                       cpu: 100m


### PR DESCRIPTION
postgresql-rds "-1" images are being deprecated; moving to postgresql-rds:12 instead
