### PR TITLE
Migrate container image/Dockerfile from UBI8 to UBI9

### DIFF
--- a/.github/workflows/checkupdate.yml
+++ b/.github/workflows/checkupdate.yml
@@ -20,7 +20,7 @@ jobs:
         run: sudo apt-get install -y skopeo
       - name: check change
         run: |
-          skopeo inspect docker://registry.access.redhat.com/ubi8/ubi-minimal:latest | grep -Po '(?<="Digest": ")([^"]+)' \
+          skopeo inspect docker://registry.access.redhat.com/ubi9/ubi-minimal:latest | grep -Po '(?<="Digest": ")([^"]+)' \
             | head -n1 > .baseimage
           docker run --rm --entrypoint sh -u 0 quay.io/cloudservices/policies-ui-backend:latest -c \
             'microdnf update > /dev/null; rpm -qa | sort | sha256sum' \

--- a/src/main/docker/Dockerfile.jvm
+++ b/src/main/docker/Dockerfile.jvm
@@ -3,21 +3,21 @@
 ###
 
 # Build the project
-FROM registry.access.redhat.com/ubi8/openjdk-17:latest AS build
+FROM registry.access.redhat.com/ubi9/openjdk-17:latest AS build
 USER root
 COPY . /home/jboss
 WORKDIR /home/jboss
 RUN ./mvnw clean package -DskipTests --no-transfer-progress
 
 # Build the container
-FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
 
 ARG JAVA_PACKAGE=java-17-openjdk-headless
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en'
 
 # Install java
 # Also set up permissions for user `1001`
-RUN microdnf install openssl curl ca-certificates ${JAVA_PACKAGE} \
+RUN microdnf install -y openssl ca-certificates ${JAVA_PACKAGE} \
     && microdnf update \
     && microdnf clean all \
     && mkdir /deployments \


### PR DESCRIPTION
This PR should replace of using UBI8 images with UBI9.
I was able to build new image with:
```
podman build . -f ./src/main/docker/Dockerfile.jvm -t test_build_policies_ui_backend --ulimit=nofile=4096
```


I confirmed that curl exists in the final image as I had to remove it from dockerfile due to installation conflict:
```
podman run --rm -it --entrypoint=sh localhost/test_build_policies_ui_backend:latest
sh-5.1$ 
sh-5.1$ curl --version
curl 7.76.1 (x86_64-redhat-linux-gnu) libcurl/7.76.1 OpenSSL/3.0.7 zlib/1.2.11 nghttp2/1.43.0
Release-Date: 2021-04-14
Protocols: file ftp ftps http https 
Features: alt-svc AsynchDNS GSS-API HTTP2 HTTPS-proxy IPv6 Kerberos Largefile libz NTLM SPNEGO SSL UnixSockets
```

RHINENG-12536