### PR TITLE
fix: do not use public pg schema

### DIFF
--- a/src/main/resources/db/migration/V19__POL-650_add_org_id_columns.sql
+++ b/src/main/resources/db/migration/V19__POL-650_add_org_id_columns.sql
@@ -7,9 +7,9 @@ CREATE TABLE org_id_latest_update (
 ALTER TABLE policy
   ADD COLUMN org_id text;
 
-CREATE INDEX ix_policy_org_id ON public.policy (org_id);
+CREATE INDEX ix_policy_org_id ON policy (org_id);
 
 ALTER TABLE policies_history
   ADD COLUMN org_id text;
 
-CREATE INDEX ix_policies_history_org_id ON public.policies_history (org_id);
+CREATE INDEX ix_policies_history_org_id ON policies_history (org_id);

--- a/src/main/resources/db/migration/V6.sql
+++ b/src/main/resources/db/migration/V6.sql
@@ -1,1 +1,1 @@
-alter table public.policy ADD column ctime timestamp default now()
+alter table policy ADD column ctime timestamp default now()


### PR DESCRIPTION
In order to have Policies running on different PG schemas, the migrations should not use fully qualified table names with the "public" schema.  Rather names of tables should stay schema-less, to leverage default schema set by search_path.