### PR TITLE
Revert "fix: do not use public pg schema"

### DIFF
--- a/src/main/resources/db/migration/V19__POL-650_add_org_id_columns.sql
+++ b/src/main/resources/db/migration/V19__POL-650_add_org_id_columns.sql
@@ -7,9 +7,9 @@ CREATE TABLE org_id_latest_update (
 ALTER TABLE policy
   ADD COLUMN org_id text;
 
-CREATE INDEX ix_policy_org_id ON policy (org_id);
+CREATE INDEX ix_policy_org_id ON public.policy (org_id);
 
 ALTER TABLE policies_history
   ADD COLUMN org_id text;
 
-CREATE INDEX ix_policies_history_org_id ON policies_history (org_id);
+CREATE INDEX ix_policies_history_org_id ON public.policies_history (org_id);

--- a/src/main/resources/db/migration/V6.sql
+++ b/src/main/resources/db/migration/V6.sql
@@ -1,1 +1,1 @@
-alter table policy ADD column ctime timestamp default now()
+alter table public.policy ADD column ctime timestamp default now()


### PR DESCRIPTION
Reverts RedHatInsights/policies-ui-backend#735 as it violates migration checksum:
```
2025-01-07 13:14:05,403 ERROR [io.qua.run.Application] (main) Failed to start application: java.lang.RuntimeException: Failed to start quarkus
	at io.quarkus.runner.ApplicationImpl.doStart(Unknown Source)
	at io.quarkus.runtime.Application.start(Application.java:101)
	at io.quarkus.runtime.ApplicationLifecycleManager.run(ApplicationLifecycleManager.java:119)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:71)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:44)
	at io.quarkus.runtime.Quarkus.run(Quarkus.java:124)
	at io.quarkus.runner.GeneratedMain.main(Unknown Source)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.doRun(QuarkusEntryPoint.java:62)
	at io.quarkus.bootstrap.runner.QuarkusEntryPoint.main(QuarkusEntryPoint.java:33)
Caused by: org.flywaydb.core.api.exception.FlywayValidateException: Validate failed: Migrations have failed validation
```