### PR TITLE
fix(db): changes on alerady applied migrations

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,6 +24,10 @@ quarkus.flyway.baseline-version=1
 quarkus.flyway.sql-migration-prefix=V
 # quarkus.flyway.repeatable-sql-migration-prefix=K
 
+# Disable validations as there was a change in already applied migrations.
+# An alternative woudld be to repair the already applied migrations with a repair command.
+quarkus.flyway.validateOnMigrate=false
+
 # Sentry logging. Off by default, enabled on OpenShift
 # See https://quarkus.io/guides/logging-sentry#in-app-packages
 quarkus.log.sentry=false


### PR DESCRIPTION
Fixes validation violations on already applied migrations, as they have been changed, by disabling the validations (checksums).

An alternative woudld be to repair the already applied migrations with a repair command.  However, that would require an active involvement on all running instances.

Supersedes #740 