### PR TITLE
fix(db): repair already applied migrations

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,6 +15,8 @@ quarkus.flyway.migrate-at-start=true
 
 # Flyway optional config properties
 quarkus.flyway.baseline-on-migrate=true
+# repair already applied migrations (since they have changed retroactively)
+quarkus.flyway.repair-at-start=true
 quarkus.flyway.baseline-version=1
 # quarkus.flyway.baseline-description=Initial version
 # quarkus.flyway.connect-retries=10


### PR DESCRIPTION
Runs repair on already applied migrations on start to match migrations that have been changed retroactively.

Ref: https://quarkus.io/version/3.15/guides/flyway