### PR TITLE
chore(deps): bump quarkus.platform.version (#772)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>com.redhat.quarkus.platform</quarkus.platform.group-id>
-    <quarkus.platform.version>3.15.3.redhat-00002</quarkus.platform.version>
+    <quarkus.platform.version>3.15.4.redhat-00001</quarkus.platform.version>
     <surefire-plugin.version>3.0.0</surefire-plugin.version>
     <maven-jar-plugin.version>3.3.0</maven-jar-plugin.version>
     <jacoco.version>0.8.12</jacoco.version>


### PR DESCRIPTION
Bumps `quarkus.platform.version` from 3.15.3.SP2-redhat-00001 to 3.15.4.redhat-00001.

Updates `com.redhat.quarkus.platform:quarkus-bom` from 3.15.3.SP2-redhat-00001 to 3.15.4.redhat-00001
- [Commits](https://github.com/quarkusio/quarkus-platform/commits)

Updates `com.redhat.quarkus.platform:quarkus-maven-plugin` from 3.15.3.SP2-redhat-00001 to 3.15.4.redhat-00001
- [Commits](https://github.com/quarkusio/quarkus-platform/commits)

---
updated-dependencies:
- dependency-name: com.redhat.quarkus.platform:quarkus-bom dependency-version: 3.15.4.redhat-00001 dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: com.redhat.quarkus.platform:quarkus-maven-plugin dependency-version: 3.15.4.redhat-00001 dependency-type: direct:production update-type: version-update:semver-patch ...