### PR TITLE
 RHINENG-19011: Use Red Hat image instead of quay

### DIFF
--- a/.rhcicd/do-nothing.yaml
+++ b/.rhcicd/do-nothing.yaml
@@ -13,7 +13,7 @@ objects:
       spec:
         containers:
         - name: policies-do-nothing
-          image: quay.io/app-sre/ubi8-ubi-minimal:8.6-902
+          image: registry.access.redhat.com/ubi8/ubi-minimal:8.6-902
           resources:
             limits:
               cpu: 200m


### PR DESCRIPTION
Use RedHat's ubi8-minimal image instead of quay.io/app-sre/ubi8-ubi-minimal as part of Konflux onboarding effort