### PR TITLE
chore: configure renovate to only run on master branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,7 @@
     "schedule": [
         "* 3-10 * * 1"
     ],
+    "baseBranches": ["master"],
     "ignorePaths": [
       ".pre-commit-config.yaml"
     ]


### PR DESCRIPTION
Currently, mintmaker will try to update all onboarded components but this is unnecessary for SC branches and just clutters the repo PR list. Only allowing renovate to run on main/master should help.