### PR TITLE
fix(ci): Enable renovate updates for tekton pipelines anytime

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,10 @@
     "extends": [
         "github>konflux-ci/mintmaker//config/renovate/renovate.json"
     ],
+    "tekton": {
+        "includePaths": [".tekton/**"],
+        "schedule": ["at any time"]
+    },
     "schedule": [
         "* 3-10 * * 1"
     ],


### PR DESCRIPTION
## Summary by Sourcery

CI:
- Enable Renovate updates for Tekton pipeline dependencies outside of the previously configured schedule